### PR TITLE
Allow a non-default shouldComponentUpdateComparator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -167,7 +167,8 @@ abstract class ComponentBase<P extends React.Props<any>, S extends Object> exten
     }
 
     shouldComponentUpdate(nextProps: P, nextState: S): boolean {
-        return !_.isEqual(this.state, nextState) || !_.isEqual(this.props, nextProps);
+        return !Options.shouldComponentUpdateComparator(this.state, nextState) ||
+                !Options.shouldComponentUpdateComparator(this.props, nextProps);
     }
 
     isComponentMounted(): boolean {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -13,6 +13,8 @@ export interface IOptions {
     setTimeout: (callback: () => void, timeoutMs?: number) => number;
     clearTimeout: (id: number) => void;
 
+    shouldComponentUpdateComparator: <T>(values: T, compareTo: T) => boolean;
+
     // Enables development mode -- more run-time checks.  By default, matches the NODE_ENV environment variable -- only set to true when
     // NODE_ENV is set and is set to something other than "production".
     development: boolean;
@@ -26,6 +28,8 @@ declare var process: IProcess;
 let OptionsVals: IOptions = {
     setTimeout: setTimeout.bind(null),
     clearTimeout: clearTimeout.bind(null),
+
+    shouldComponentUpdateComparator: _.isEqual.bind(_),
 
     development: typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production'
 };


### PR DESCRIPTION
This allows for a global override or the Resub.ComponentBase shouldComponentUpdate comparison behaviour
Some people may choose to return true here if their models are not immutable