### PR TITLE
Small optimization to triggering logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -168,7 +168,8 @@ export abstract class StoreBase {
 
         if (this._throttleMs && !StoreBase._bypassThrottle) {
             // Needs to accumulate and trigger later -- start a timer if we don't have one running already
-            if (!this._throttleTimerId) {
+            // If there are no callbacks, don't bother setting up the timer
+            if (!this._throttleTimerId && this._gatheredCallbacks.size !== 0) {
                 this._throttleTimerId = Options.setTimeout(this._resolveThrottledCallbacks, this._throttleMs);
             }
         } else {


### PR DESCRIPTION
If a store uses deferred triggers, don't bother setting up a deferral if we've determined that there's nothing to trigger on (current or pending)