### PR TITLE
[0.0.16] Fix error with lodash exported typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -318,12 +318,4 @@ export abstract class StoreBase {
     protected _isTrackingKey(key: string) {
         return !!this._subscriptions[key] || !!this._autoSubscriptions[key];
     }
-
-    test_getSubscriptions() {
-        return this._subscriptions;
-    }
-
-    test_getAutoSubscriptions() {
-        return this._autoSubscriptions;
-    }
 }

--- a/tests/AutoSubscribeTests.tsx
+++ b/tests/AutoSubscribeTests.tsx
@@ -124,6 +124,16 @@ class SimpleStore extends StoreBase {
     test_getSubscriptionKeys() {
         return this._getSubscriptionKeys();
     }
+
+    test_getSubscriptions() {
+        // Access private internal state of store
+        return (this as any)._subscriptions;
+    }
+
+    test_getAutoSubscriptions() {
+        // Access private internal state of store
+        return (this as any)._autoSubscriptions;
+    }
 }
 
 // Instance of the SimpleStore used throughout the test. Re-created for each test.


### PR DESCRIPTION
Could not find a declaration file for module 'lodash'. '/src/reactxp/samples/hello-resub/node_modules/lodash/lodash.js' implicitly has an 'any' type.