### PR TITLE
Markda/all optional target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {
@@ -12,7 +12,8 @@
   "dependencies": {
     "@types/lodash": "^4.14.62",
     "assert": "^1.4.1",
-    "lodash": "3.x || 4.x"
+    "lodash": "3.x || 4.x",
+    "tslib": "^1.7.1"
   },
   "peerDependencies": {
     "react": "^15.0.0"
@@ -44,5 +45,5 @@
     "stores"
   ],
   "license": "MIT",
-	"types": "dist/src/ReSub.d.ts"
+  "types": "dist/src/ReSub.d.ts"
 }

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -106,6 +106,7 @@ let handlerWrapper: HandlerWraper = null;
 function createAutoSubscribeWrapper<T extends Function>(handler: AutoSubscribeHandler, useAutoSubscriptions: AutoOptions, existingMethod: T,
         thisArg: any): T {
     // Note: we need to be given 'this', so cannot use '=>' syntax.
+    // Note: T might have other properties (e.g. T = { (): void; bar: number; }). We don't support that and need a cast.
     return <T><any>function AutoSubscribeWrapper(this: any, ...args: any[]) {
 
         // Decorators are given 'this', but normal callers can supply it as a parameter.
@@ -147,6 +148,7 @@ export function forbidAutoSubscribeWrapper<T extends Function>(existingMethod: T
 // Hooks up the handler for @autoSubscribe methods called later down the call stack.
 export function enableAutoSubscribe(handler: AutoSubscribeHandler): MethodDecorator {
     return <T>(target: InstanceTarget, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => {
+        // Note: T might have other properties (e.g. T = { (): void; bar: number; }). We don't support that and need a cast/assert.
         const existingMethod = <Function><any>descriptor.value;
         assert.ok(_.isFunction(existingMethod), 'Can only use @enableAutoSubscribe on methods');
 
@@ -199,6 +201,7 @@ function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues: string[])
         targetWithMetadata.__resubMetadata[methodName].hasAutoSubscribeDecorator = true;
 
         // Save the method being decorated. Note this might not be the original method if already decorated.
+        // Note: T might have other properties (e.g. T = { (): void; bar: number; }). We don't support that and need a cast/assert.
         const existingMethod = <Function><any>descriptor.value;
         assert.ok(_.isFunction(existingMethod), 'Can only use @autoSubscribe on methods');
 
@@ -310,6 +313,7 @@ export function disableWarnings<T extends Function>(target: InstanceTarget, meth
     const existingMethod = descriptor.value;
 
     // Note: we need to be given 'this', so cannot use '=>' syntax.
+    // Note: T might have other properties (e.g. T = { (): void; bar: number; }). We don't support that and need a cast.
     descriptor.value = <T><any>function DisableWarnings(this: any, ...args: any[]) {
         assert.ok(targetWithMetadata.__resubMetadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
 
@@ -360,6 +364,7 @@ export function warnIfAutoSubscribeEnabled<T extends Function>(target: InstanceT
     const originalMethod = descriptor.value;
 
     // Note: we need to be given 'this', so cannot use '=>' syntax.
+    // Note: T might have other properties (e.g. T = { (): void; bar: number; }). We don't support that and need a cast.
     descriptor.value = <T><any>function WarnIfAutoSubscribeEnabled(this: any, ...args: any[]) {
         assert.ok(targetWithMetadata.__resubMetadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
 

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -68,15 +68,17 @@ import Decorator = require('./Decorator');
 import Options from './Options';
 import { StoreBase } from './StoreBase';
 
-export type MetadataIndex = { [methodName: string]: { hasAutoSubscribeDecorator?: boolean; hasIndex?: boolean; index?: number } };
-export type MetadataProperties = { __decorated?: boolean; };
-export type Metadata = MetadataIndex & MetadataProperties;
+type MetadataIndex = { [methodName: string]: { hasAutoSubscribeDecorator?: boolean; hasIndex?: boolean; index?: number } };
+type MetadataProperties = { __decorated?: boolean; };
+type Metadata = MetadataIndex & MetadataProperties;
 
 // Class prototype for decorated methods/parameters.
-export type InstanceTarget = {
+type InstanceTargetWithMetadata = InstanceTarget & {
     // Extra property shoved onto targets to hold auto-subscribe metadata.
-    __metadata?: Metadata;
+    __resubMetadata?: Metadata;
 };
+
+export type InstanceTarget = {};
 
 // Callback and info for setting up auto-subscriptions.
 export interface AutoSubscribeHandler {
@@ -143,11 +145,12 @@ export function forbidAutoSubscribeWrapper<T extends Function>(existingMethod: T
 }
 
 // Hooks up the handler for @autoSubscribe methods called later down the call stack.
-export function enableAutoSubscribe<T extends Function>(handler: AutoSubscribeHandler): MethodDecorator {
-    return (target: InstanceTarget, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => {
-        const existingMethod = descriptor.value;
+export function enableAutoSubscribe(handler: AutoSubscribeHandler): MethodDecorator {
+    return <T>(target: InstanceTarget, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => {
+        const existingMethod = <Function><any>descriptor.value;
+        assert.ok(_.isFunction(existingMethod), 'Can only use @enableAutoSubscribe on methods');
 
-        descriptor.value = enableAutoSubscribeWrapper(handler, existingMethod, undefined);
+        descriptor.value = <T><any>enableAutoSubscribeWrapper(handler, existingMethod, undefined);
 
         return descriptor;
     };
@@ -162,17 +165,17 @@ function _tryFinally<TResult>(tryFunc: () => TResult, finallyFunc: Function): TR
     }
 }
 
-export var AutoSubscribeStore: ClassDecorator = (func: Function) => {
-    const target = <InstanceTarget> func.prototype;
-    target.__metadata = target.__metadata || {};
+export var AutoSubscribeStore: ClassDecorator = <TFunction extends Function>(func: TFunction): TFunction => {
+    const target = <InstanceTargetWithMetadata> func.prototype;
+    target.__resubMetadata = target.__resubMetadata || {};
 
-    target.__metadata.__decorated = true;
+    target.__resubMetadata.__decorated = true;
 
     if (Options.development) {
         // Add warning for non-decorated methods.
         _.forEach(Object.getOwnPropertyNames(target), property => {
             if (_.isFunction(target[property]) && property !== 'constructor') {
-                const metaForMethod = target.__metadata[property];
+                const metaForMethod = target.__resubMetadata[property];
                 if (!metaForMethod || !metaForMethod.hasAutoSubscribeDecorator) {
                     Decorator.decorate([
                         warnIfAutoSubscribeEnabled
@@ -186,20 +189,22 @@ export var AutoSubscribeStore: ClassDecorator = (func: Function) => {
 };
 
 // Triggers the handler of the most recent @enableAutoSubscribe method called up the call stack.
-function makeAutoSubscribeDecorator<T extends Function>(shallow = false, defaultKeyValues: string[]): MethodDecorator {
-    return (target: InstanceTarget, methodName: string, descriptor: TypedPropertyDescriptor<T>) => {
-        target.__metadata = target.__metadata || {};
-        target.__metadata[methodName] = target.__metadata[methodName] || {};
+function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues: string[]): MethodDecorator {
+    return <T>(target: InstanceTarget, methodName: string, descriptor: TypedPropertyDescriptor<T>) => {
+        const targetWithMetadata = <InstanceTargetWithMetadata> target;
+        targetWithMetadata.__resubMetadata = targetWithMetadata.__resubMetadata || {};
+        targetWithMetadata.__resubMetadata[methodName] = targetWithMetadata.__resubMetadata[methodName] || {};
 
         // Record that the target is decorated.
-        target.__metadata[methodName].hasAutoSubscribeDecorator = true;
+        targetWithMetadata.__resubMetadata[methodName].hasAutoSubscribeDecorator = true;
 
         // Save the method being decorated. Note this might not be the original method if already decorated.
-        const existingMethod = descriptor.value;
+        const existingMethod = <Function><any>descriptor.value;
+        assert.ok(_.isFunction(existingMethod), 'Can only use @autoSubscribe on methods');
 
         // Note: we need to be given 'this', so cannot use '=>' syntax.
         descriptor.value = <T><any>function AutoSubscribe(...args: any[]) {
-            assert.ok(target.__metadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
+            assert.ok(targetWithMetadata.__resubMetadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
 
             // Just call the method if no handler is setup.
             if (!handlerWrapper || handlerWrapper.useAutoSubscriptions === AutoOptions.None) {
@@ -219,7 +224,7 @@ function makeAutoSubscribeDecorator<T extends Function>(shallow = false, default
             let specificKeyValues = defaultKeyValues;
 
             // Try to find an @key parameter in the target's metadata.
-            const metaForMethod = target.__metadata[methodName];
+            const metaForMethod = targetWithMetadata.__resubMetadata[methodName];
             assert.ok(metaForMethod, 'Internal failure: what happened to the metadata for this method?');
             if (metaForMethod.hasIndex) {
                 let keyArg: number | string = args[metaForMethod.index];
@@ -273,11 +278,12 @@ export function autoSubscribeWithKey(keyOrKeys: string|number|(string|number)[])
 // Records which parameter of an @autoSubscribe method is the key used for the subscription.
 // Note: at most one @key can be applied to each method.
 export function key(target: InstanceTarget, methodName: string, index: number) {
-    target.__metadata = target.__metadata || {};
-    target.__metadata[methodName] = target.__metadata[methodName] || {};
+    const targetWithMetadata = <InstanceTargetWithMetadata> target;
+    targetWithMetadata.__resubMetadata = targetWithMetadata.__resubMetadata || {};
+    targetWithMetadata.__resubMetadata[methodName] = targetWithMetadata.__resubMetadata[methodName] || {};
 
     // Shorthand.
-    const metaForMethod = target.__metadata[methodName];
+    const metaForMethod = targetWithMetadata.__resubMetadata[methodName];
 
     assert.ok(!metaForMethod.hasIndex, 'Can only apply @key once per method: only the first will be used: "'
         + methodName + '"@' + index);
@@ -288,11 +294,12 @@ export function key(target: InstanceTarget, methodName: string, index: number) {
 }
 
 export function disableWarnings<T extends Function>(target: InstanceTarget, methodName: string, descriptor: TypedPropertyDescriptor<T>) {
-    target.__metadata = target.__metadata || {};
-    target.__metadata[methodName] = target.__metadata[methodName] || {};
+    const targetWithMetadata = <InstanceTargetWithMetadata> target;
+    targetWithMetadata.__resubMetadata = targetWithMetadata.__resubMetadata || {};
+    targetWithMetadata.__resubMetadata[methodName] = targetWithMetadata.__resubMetadata[methodName] || {};
 
     // Record that the target is decorated.
-    target.__metadata[methodName].hasAutoSubscribeDecorator = true;
+    targetWithMetadata.__resubMetadata[methodName].hasAutoSubscribeDecorator = true;
 
     if (!Options.development) {
         // Warnings are already disabled for production.
@@ -304,7 +311,7 @@ export function disableWarnings<T extends Function>(target: InstanceTarget, meth
 
     // Note: we need to be given 'this', so cannot use '=>' syntax.
     descriptor.value = <T><any>function DisableWarnings(...args: any[]) {
-        assert.ok(target.__metadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
+        assert.ok(targetWithMetadata.__resubMetadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
 
         // Just call the method if no handler is setup.
         if (!handlerWrapper || handlerWrapper.useAutoSubscriptions === AutoOptions.None) {
@@ -345,15 +352,16 @@ export function warnIfAutoSubscribeEnabled<T extends Function>(target: InstanceT
         return descriptor;
     }
 
-    target.__metadata = target.__metadata || {};
-    target.__metadata[methodName] = target.__metadata[methodName] || {};
+    const targetWithMetadata = <InstanceTargetWithMetadata> target;
+    targetWithMetadata.__resubMetadata = targetWithMetadata.__resubMetadata || {};
+    targetWithMetadata.__resubMetadata[methodName] = targetWithMetadata.__resubMetadata[methodName] || {};
 
     // Save the method being decorated. Note this might be another decorator method.
     const originalMethod = descriptor.value;
 
     // Note: we need to be given 'this', so cannot use '=>' syntax.
     descriptor.value = <T><any>function WarnIfAutoSubscribeEnabled(...args: any[]) {
-        assert.ok(target.__metadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
+        assert.ok(targetWithMetadata.__resubMetadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
 
         assert.ok(!handlerWrapper || handlerWrapper.useAutoSubscriptions !== AutoOptions.Enabled || handlerWrapper.inAutoSubscribe,
             'Only Store methods with the @autoSubscribe decorator can be called right now (e.g. in _buildState): "' + methodName + '"');

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -106,7 +106,7 @@ let handlerWrapper: HandlerWraper = null;
 function createAutoSubscribeWrapper<T extends Function>(handler: AutoSubscribeHandler, useAutoSubscriptions: AutoOptions, existingMethod: T,
         thisArg: any): T {
     // Note: we need to be given 'this', so cannot use '=>' syntax.
-    return <T><any>function AutoSubscribeWrapper(...args: any[]) {
+    return <T><any>function AutoSubscribeWrapper(this: any, ...args: any[]) {
 
         // Decorators are given 'this', but normal callers can supply it as a parameter.
         const instance = thisArg || this;
@@ -203,7 +203,7 @@ function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues: string[])
         assert.ok(_.isFunction(existingMethod), 'Can only use @autoSubscribe on methods');
 
         // Note: we need to be given 'this', so cannot use '=>' syntax.
-        descriptor.value = <T><any>function AutoSubscribe(...args: any[]) {
+        descriptor.value = <T><any>function AutoSubscribe(this: any, ...args: any[]) {
             assert.ok(targetWithMetadata.__resubMetadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
 
             // Just call the method if no handler is setup.
@@ -310,7 +310,7 @@ export function disableWarnings<T extends Function>(target: InstanceTarget, meth
     const existingMethod = descriptor.value;
 
     // Note: we need to be given 'this', so cannot use '=>' syntax.
-    descriptor.value = <T><any>function DisableWarnings(...args: any[]) {
+    descriptor.value = <T><any>function DisableWarnings(this: any, ...args: any[]) {
         assert.ok(targetWithMetadata.__resubMetadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
 
         // Just call the method if no handler is setup.
@@ -360,7 +360,7 @@ export function warnIfAutoSubscribeEnabled<T extends Function>(target: InstanceT
     const originalMethod = descriptor.value;
 
     // Note: we need to be given 'this', so cannot use '=>' syntax.
-    descriptor.value = <T><any>function WarnIfAutoSubscribeEnabled(...args: any[]) {
+    descriptor.value = <T><any>function WarnIfAutoSubscribeEnabled(this: any, ...args: any[]) {
         assert.ok(targetWithMetadata.__resubMetadata.__decorated, 'Missing @AutoSubscribeStore class decorator: "' + methodName + '"');
 
         assert.ok(!handlerWrapper || handlerWrapper.useAutoSubscriptions !== AutoOptions.Enabled || handlerWrapper.inAutoSubscribe,

--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -175,7 +175,7 @@ abstract class ComponentBase<P extends React.Props<any>, S extends Object> exten
         return this._isMounted;
     }
 
-    protected _addSubscription(subscription: StoreSubscription<S>): StoreSubscription<S> {
+    protected _addSubscription(subscription: StoreSubscription<S>): StoreSubscription<S>|undefined {
         assert.ok(subscription.store instanceof StoreBase,
             'Subscription added with store that\'s not an StoreBase');
 
@@ -185,7 +185,7 @@ abstract class ComponentBase<P extends React.Props<any>, S extends Object> exten
                 // Do not process subscription
 
                 // TODO: save this subscription and try again when props change!
-                return;
+                return undefined;
             }
         }
 

--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -3,81 +3,21 @@
 * Author: Mark Davis
 * Copyright: Microsoft 2016
 *
-* Exposes TypeScript's __decorate function to apply a decorator. Also, documentation about applying descriptors.
+* Exposes TypeScript's __decorate function to apply a decorator.
 */
 // TypeScript should put '__decorate' in the local scope around here.
-// Note: See the '__decorate' below it for a better commented version of the same code.
+
+import { __decorate as tslib_decorate } from 'tslib';
 
 declare var __decorate: Function;
-declare var Reflect: { decorate?: Function };
 
 // Unused class. Only here so TypeScript generates the '__decorate' method.
 class FakeClassWithDecorator {
     @((FakeClassWithDecoratorPrototype: Object, fooName: string, descriptor: TypedPropertyDescriptor<any>) => descriptor)
-    foo() { return 0; }
+    foo() { return FakeClassWithDecorator; }
 }
 
-// Decorator 'target' is the prototype of the containing Method/Property/Parameter, or a constructor function for a
-// ClassDecorator.
-type Target = Object|Function;
+// Fallback to the tslib version if this doesn't work.
+__decorate = __decorate || tslib_decorate;
 
-// Unifying interface for the {Class, Property, Method, Parameter}Decorator types.
-interface Decorator {
-    // ClassDecorator
-    <T extends Function>(func: T): T|void;
-    // PropertyDecorator
-    (target: Target, propertyKey: string|symbol): void;
-    // MethodDecorator
-    <T>(target: Target, propertyKey: string|symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>|void;
-    // ParameterDecorator
-    // Note: TypeScript converts this to a decorator like (target, propertyKey) => void, with parameterIndex captured.
-    (target: Target, propertyKey: string|symbol, parameterIndex: number): void;
-}
-
-// Local copy of '__decorate', just in case TypeScript changes how they do things.
-
-// This can be called a few different ways:
-// 1. constructorFunction = __decorate(classDecorators, constructorFunction);
-// 2. __decorate(methodOrParameterDecorators, classPrototype, propertyName, null);
-// 3. __decorate(propertyDecorators, classPrototype, propertyName, previousPropertyDescriptor || undefined /* not null */);
-// 4. Something else that I do not know about.
-__decorate = __decorate || function (decorators: Decorator[], target: Target, key: string, desc: PropertyDescriptor) {
-    // Will be 2 for ClassDecorators, 4 for the others.
-    const argLength_c = arguments.length;
-    // 1. ClassDecorator: target.
-    // 2. Method/Parameter: the existing property descriptor on the object (if any).
-    // 3. Property: the given property descriptor. Usually undefined.
-    let currentDescriptor_r: Target|PropertyDescriptor = argLength_c < 3
-        ? target
-        // Note: Method and Parameter Decorators have desc === null, but PropertyDecorator has desc === void 0.
-        : desc === null
-            ? desc = Object.getOwnPropertyDescriptor(target, key)
-            : desc;
-    // decorators[i], used in the loop below.
-    let currentDecorator_d: Decorator;
-
-    if (typeof Reflect === 'object' && typeof Reflect.decorate === 'function') {
-        // Use Reflect to do the work.
-        currentDescriptor_r = Reflect.decorate(decorators, target, key, desc);
-    } else {
-        // No Refect: do it ourself.
-        for (var i = decorators.length - 1; i >= 0; i--) {
-            currentDecorator_d = decorators[i];
-            if (currentDecorator_d) {
-                // Apply the decorator to the current descriptor, resulting in the new descriptor.
-                currentDescriptor_r = (argLength_c < 3
-                    ? currentDecorator_d(currentDescriptor_r as Function)
-                    : argLength_c > 3
-                        ? currentDecorator_d(target, key, currentDescriptor_r)
-                        : currentDecorator_d(target, key)
-                ) as Target
-                    // Keep using the current descriptor if not given a replacement.
-                    || currentDescriptor_r;
-            }
-        }
-    }
-    // Return the current desciptor. Also use Object.defineProperty if this is not a ClassDecorator.
-    return (argLength_c > 3 && currentDescriptor_r && Object.defineProperty(target, key, currentDescriptor_r)), currentDescriptor_r;
-};
-
-export var decorate = __decorate;
+export const decorate = __decorate;

--- a/src/typings/react.d.ts
+++ b/src/typings/react.d.ts
@@ -109,7 +109,8 @@ declare namespace __React {
     // ----------------------------------------------------------------------
 
     // Base component for plain JS classes
-    class Component<P, S> implements ComponentLifecycle<P, S> {
+    interface Component<P = {}, S = {}> extends ComponentLifecycle<P, S> { }
+    class Component<P = {}, S = {}> implements ComponentLifecycle<P, S> {
         static propTypes: ValidationMap<any>;
         static contextTypes: ValidationMap<any>;
         static childContextTypes: ValidationMap<any>;

--- a/tests/StoreBaseTests.ts
+++ b/tests/StoreBaseTests.ts
@@ -8,7 +8,6 @@
 
 import assert = require('assert');
 import _ = require('lodash');
-import React = require('react');
 
 import { StoreBase } from '../src/StoreBase';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,19 @@
         "module": "commonjs",
         "target": "es5",
         "experimentalDecorators": true,
-        "noImplicitAny": true,
         "suppressImplicitAnyIndexErrors":  true,
-        "outDir": "dist/"
+        "outDir": "dist/",
+        "typeRoots": [
+            "node_modules/@types"
+        ],
+        
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "forceConsistentCasingInFileNames": true,
+        
+        "strictNullChecks": false
     },
     
     "filesGlob": [


### PR DESCRIPTION
[0.0.17] Updated to support TypeScript 2.4. They added extra type-checks around types with all-optional properties (like 'InstanceTarget').

Also enabling more checks via the TypeScript compiler flags. Not strictNullChecks since that would require functional changes.