### PR TITLE
[0.0.19] Fix a rare unsubscription error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/tests/StoreBaseTests.ts
+++ b/tests/StoreBaseTests.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * StoreBaseTests.ts
  * Author: David de Regt
  * Copyright: Microsoft 2016
@@ -148,5 +148,33 @@ describe('StoreBaseTests', function () {
 
             done();
         }, 200);
+    });
+
+    it('Double Trigger w/ Unsubscribe', (done: Function) => {
+        let store = new BraindeadStore();
+
+        let callCount1 = 0;
+        const token1 = store.subscribe(() => {
+            callCount1++;
+            store.unsubscribe(token1);
+            store.emitAll();
+        });
+
+        let callCount2 = 0;
+        const token2 = store.subscribe(() => {
+            callCount2++;
+            store.unsubscribe(token2);
+            store.emitAll();
+        });
+
+        // Try all emit - Each subscription should the called once and the store should trigger multiple times
+        store.emitAll();
+
+        _.delay(() => {
+            assert.equal(callCount1, 1);
+            assert.equal(callCount2, 1);
+
+            done();
+        }, 100);
     });
 });


### PR DESCRIPTION
This can occur in the case where more than 2 callees are subscribed to a store and unsubscribe during the callback.  If one of the N-1 callees cause the store to trigger again, all the remaining callbacks will be queued and called again.  This will result in some of the callers calling unsubscribe more than once
Add a unit test for this case