### PR TITLE
Setting the strict nulls flag on the typescript compiler, and unifyin…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,24 +10,24 @@
     "tslint": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.62",
+    "@types/lodash": "^4.14.68",
     "assert": "^1.4.1",
-    "lodash": "3.x || 4.x",
+    "lodash": "^4.17.0",
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
     "react": "^15.0.0"
   },
   "devDependencies": {
+    "awesome-typescript-loader": "^3.2.1",
     "mocha": "^2.3.4",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",
     "tslint": "^5.0.0",
     "tslint-microsoft-contrib": "^4.0.1",
-    "ts-loader": "^0.8.2",
     "typescript": "2.6.0-dev.20170826",
-    "webpack": "^1.12.14"
+    "webpack": "^3.3.0"
   },
   "repository": {
     "type": "git",

--- a/src/MapShim.ts
+++ b/src/MapShim.ts
@@ -15,10 +15,10 @@ import _ = require('./lodashMini');
 export interface Map<K, V> {
     clear(): void;
     delete(key: K): boolean;
-    forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void): void;
-    get(key: K): V;
+    forEach(callbackfn: (value: V|undefined|null, index: K, map: Map<K, V>) => void): void;
+    get(key: K): V|undefined|null;
     has(key: K): boolean;
-    set(key: K, value?: V): Map<K, V>;
+    set(key: K, value: V|undefined|null): Map<K, V>;
     size: number;
 }
 
@@ -31,7 +31,7 @@ declare var Map: MapConstructor;
 
 interface IMapShimItem<K, V> {
     key: K;
-    value: V;
+    value: V|undefined|null;
 }
 
 class MapShim<K, V> implements Map<K, V> {
@@ -55,11 +55,11 @@ class MapShim<K, V> implements Map<K, V> {
         return true;
     }
 
-    forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void): void {
+    forEach(callbackfn: (value: V|undefined|null, index: K, map: Map<K, V>) => void): void {
         _.forEach(this._mapShimItems, item => callbackfn(item.value, item.key, this));
     }
 
-    get(key: K): V {
+    get(key: K): V|undefined|null {
         const index = _.findIndex(this._mapShimItems, item => item.key === key);
         if (index === -1) {
             return undefined;

--- a/src/MapShim.ts
+++ b/src/MapShim.ts
@@ -15,10 +15,10 @@ import _ = require('./lodashMini');
 export interface Map<K, V> {
     clear(): void;
     delete(key: K): boolean;
-    forEach(callbackfn: (value: V|undefined|null, index: K, map: Map<K, V>) => void): void;
-    get(key: K): V|undefined|null;
+    forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void): void;
+    get(key: K): V|undefined;
     has(key: K): boolean;
-    set(key: K, value: V|undefined|null): Map<K, V>;
+    set(key: K, value: V): Map<K, V>;
     size: number;
 }
 
@@ -31,7 +31,7 @@ declare var Map: MapConstructor;
 
 interface IMapShimItem<K, V> {
     key: K;
-    value: V|undefined|null;
+    value: V;
 }
 
 class MapShim<K, V> implements Map<K, V> {
@@ -55,11 +55,11 @@ class MapShim<K, V> implements Map<K, V> {
         return true;
     }
 
-    forEach(callbackfn: (value: V|undefined|null, index: K, map: Map<K, V>) => void): void {
+    forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void): void {
         _.forEach(this._mapShimItems, item => callbackfn(item.value, item.key, this));
     }
 
-    get(key: K): V|undefined|null {
+    get(key: K): V|undefined {
         const index = _.findIndex(this._mapShimItems, item => item.key === key);
         if (index === -1) {
             return undefined;
@@ -72,7 +72,7 @@ class MapShim<K, V> implements Map<K, V> {
         return _.some(this._mapShimItems, item => item.key === key);
     }
 
-    set(key: K, value?: V): Map<K, V> {
+    set(key: K, value: V): Map<K, V> {
         const item = _.find(this._mapShimItems, item => item.key === key);
         if (item) {
             item.value = value;

--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -36,7 +36,7 @@ export abstract class StoreBase {
 
     storeId = _.uniqueId('store');
 
-    private _gatheredCallbacks = new MapShim<SubscriptionCallbackFunction, string[]>();
+    private _gatheredCallbacks = new MapShim<SubscriptionCallbackFunction, string[]|null>();
 
     private _throttleMs: number;
     private _throttleTimerId: number|undefined;
@@ -144,7 +144,7 @@ export abstract class StoreBase {
             _.forEach(this._subscriptions[StoreBase.Key_All], callback => {
                 const existingKeys = this._gatheredCallbacks.get(callback);
                 if (existingKeys === undefined) {
-                    this._gatheredCallbacks.set(callback, _.clone(keys));
+                    this._gatheredCallbacks.set(callback, _.clone(keys!!!));
                 } else if (existingKeys === null) {
                     // Do nothing since it's already an all-key-trigger
                 } else {
@@ -158,7 +158,7 @@ export abstract class StoreBase {
             _.forEach(this._autoSubscriptions[StoreBase.Key_All], sub => {
                 const existingKeys = this._gatheredCallbacks.get(sub.callback);
                 if (existingKeys === undefined) {
-                    this._gatheredCallbacks.set(sub.callback, _.clone(keys));
+                    this._gatheredCallbacks.set(sub.callback, _.clone(keys!!!));
                 } else if (existingKeys === null) {
                     // Do nothing since it's already an all-key-trigger
                 } else {

--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -39,7 +39,7 @@ export abstract class StoreBase {
     private _gatheredCallbacks = new MapShim<SubscriptionCallbackFunction, string[]>();
 
     private _throttleMs: number;
-    private _throttleTimerId: number;
+    private _throttleTimerId: number|undefined;
 
     private _bypassTriggerBlocks: boolean;
     private _triggerBlocked = false;
@@ -90,7 +90,7 @@ export abstract class StoreBase {
     // If you trigger a specific set of keys, then it will only trigger that specific set of callbacks (and subscriptions marked
     // as "All" keyed).  If the key is all, it will trigger all callbacks.
     protected trigger(keyOrKeys?: string|number|(string|number)[]) {
-        let keys: string[];
+        let keys: string[]|undefined;
 
         // trigger(0) is valid, ensure that we catch this case
         if (keyOrKeys || _.isNumber(keyOrKeys)) {
@@ -218,7 +218,8 @@ export abstract class StoreBase {
         storedCallbacks.forEach((keys, callback) => {
             // Do a quick dedupe on keys
             const uniquedKeys = keys ? _.uniq(keys) : keys;
-            callback(uniquedKeys);
+            // Convert null key (meaning "all") to undefined for the callback.
+            callback(uniquedKeys || undefined);
         });
         this._isTriggering = false;
 

--- a/src/lodashMini.ts
+++ b/src/lodashMini.ts
@@ -9,6 +9,7 @@
 
  import bind = require('lodash/bind');
  import forEach = require('lodash/forEach');
+ import extend = require('lodash/extend');
  import isArray = require('lodash/isArray');
  import isFunction = require('lodash/isFunction');
  import isNumber = require('lodash/isNumber');
@@ -45,6 +46,7 @@
     isString,
     map,
     noop,
+    extend,
     get,
     isEqual,
     isEmpty,

--- a/tests/AutoSubscribeTests.tsx
+++ b/tests/AutoSubscribeTests.tsx
@@ -186,9 +186,9 @@ interface SimpleProps extends React.Props<any> {
 
 // State for component. Could use 'Stateless' if component has no state.
 interface SimpleState {
-    storeDatas?: StoreData[];
-    stateChanges?: number;
-    keyedDataSum?: number;
+    storeDatas: StoreData[];
+    stateChanges: number;
+    keyedDataSum: number;
 }
 
 class SimpleComponent extends ComponentBase<SimpleProps, SimpleState> {
@@ -197,8 +197,8 @@ class SimpleComponent extends ComponentBase<SimpleProps, SimpleState> {
     // for which this component is subscribed (e.g. SimpleStore).
 
     // Auto-subscriptions are enabled in _buildState due to ComponentBase.
-    protected _buildState(props: SimpleProps, initialBuild: boolean): SimpleState {
-        const newState: SimpleState = {
+    protected _buildState(props: SimpleProps, initialBuild: boolean): Partial<SimpleState> {
+        const newState: Partial<SimpleState> = {
             keyedDataSum: 0
         };
         if (props.test_useAll) {
@@ -217,7 +217,7 @@ class SimpleComponent extends ComponentBase<SimpleProps, SimpleState> {
         }
 
         newState.storeDatas = _.map(props.ids, id => SimpleStoreInstance.getStoreData(id));
-        newState.stateChanges = initialBuild ? 1 : this.state.stateChanges + 1;
+        newState.stateChanges = initialBuild ? 1 : this.state.stateChanges!!! + 1;
         return newState;
     }
 

--- a/tests/AutoSubscribeTests.tsx
+++ b/tests/AutoSubscribeTests.tsx
@@ -217,7 +217,7 @@ class SimpleComponent extends ComponentBase<SimpleProps, SimpleState> {
         }
 
         newState.storeDatas = _.map(props.ids, id => SimpleStoreInstance.getStoreData(id));
-        newState.stateChanges = initialBuild ? 1 : this.state.stateChanges!!! + 1;
+        newState.stateChanges = initialBuild ? 1 : this.state.stateChanges + 1;
         return newState;
     }
 

--- a/tests/StoreBaseTests.ts
+++ b/tests/StoreBaseTests.ts
@@ -16,10 +16,10 @@ class BraindeadStore extends StoreBase {
     Key_Something2 = 'def';
 
     foundAll = false;
-    allKeys: string[] = undefined;
+    allKeys: string[]|undefined = undefined;
     allSub: number;
     foundKey = false;
-    keyKeys: string[] = undefined;
+    keyKeys: string[]|undefined = undefined;
     keySub: number;
 
     setupSubs() {
@@ -59,8 +59,8 @@ describe('StoreBaseTests', function () {
         // Try all emit
         store.emitAll();
         assert.ok(store.foundAll && store.foundKey);
-        assert.equal(store.allKeys, null);
-        assert.equal(store.keyKeys, null);
+        assert.equal(store.allKeys, undefined);
+        assert.equal(store.keyKeys, undefined);
         store.foundAll = store.foundKey = false;
         store.allKeys = store.keyKeys = undefined;
 
@@ -87,10 +87,10 @@ describe('StoreBaseTests', function () {
         store.emitSomethings();
         assert.ok(!store.foundAll && !store.foundKey);
 
-        // unblock and make sure the dedupe logic works (should just emit null, since we did an all emit, which overrides the keyed ones)
+        // unblock and make sure the dedupe logic works (should just emit undefined, since we did an all emit, which overrides the keyed ones)
         StoreBase.popTriggerBlock();
-        assert.ok(_.isEqual(store.allKeys, null));
-        assert.ok(_.isEqual(store.keyKeys, null));
+        assert.ok(_.isEqual(store.allKeys, undefined));
+        assert.ok(_.isEqual(store.keyKeys, undefined));
         assert.ok(store.foundAll && store.foundKey);
         store.foundAll = store.foundKey = false;
         store.allKeys = store.keyKeys = undefined;
@@ -113,7 +113,7 @@ describe('StoreBaseTests', function () {
         // Try all emit
         store.emitAll();
         assert.ok(store.foundAll);
-        assert.equal(store.allKeys, null);
+        assert.equal(store.allKeys, undefined);
         store.foundAll = false;
         store.allKeys = undefined;
 
@@ -121,7 +121,7 @@ describe('StoreBaseTests', function () {
         StoreBase.pushTriggerBlock();
         store.emitAll();
         assert.ok(store.foundAll);
-        assert.equal(store.allKeys, null);
+        assert.equal(store.allKeys, undefined);
         store.foundAll = false;
         store.allKeys = undefined;
 

--- a/tests/StoreBaseTests.ts
+++ b/tests/StoreBaseTests.ts
@@ -87,7 +87,8 @@ describe('StoreBaseTests', function () {
         store.emitSomethings();
         assert.ok(!store.foundAll && !store.foundKey);
 
-        // unblock and make sure the dedupe logic works (should just emit undefined, since we did an all emit, which overrides the keyed ones)
+        // unblock and make sure the dedupe logic works (should just emit undefined, since we did an all emit,
+        // which overrides the keyed ones)
         StoreBase.popTriggerBlock();
         assert.ok(_.isEqual(store.allKeys, undefined));
         assert.ok(_.isEqual(store.keyKeys, undefined));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,12 +18,8 @@
         "noUnusedLocals": true,
         "forceConsistentCasingInFileNames": true,
         
-        "strictNullChecks": false
+        "strictNullChecks": true
     },
-    
-    "filesGlob": [
-        "src/**/*{ts,tsx}"
-    ],
     
     "exclude": [
         "dist",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,19 +9,19 @@ var webpackConfig = {
     },
 
     resolve: {
-        root: [
+        modules: [
             path.resolve('./src'),
             path.resolve('./node_modules')
         ],
-        extensions: ['', '.ts', '.tsx', '.js']
+        extensions: ['.ts', '.tsx', '.js']
     },
     
     module: {
-        loaders: [{
+        rules: [{
             // Compile TS.
             test: /\.tsx?$/, 
             exclude: /node_modules/,
-            loader: 'ts-loader'
+            loader: 'awesome-typescript-loader'
         }]
     }  
 };


### PR DESCRIPTION
…g some of the awkward mixed null/undefined behavior to now cleanly emit only undefineds.  We still use null internally as an awkward "all keys" tri-state on StoreBase, but now we emit an undefined key instead of a null key for "all".  Fixed some other probably innocuous bugs in the process.  Fixed unit tests to work again (hadn't worked on lodash 3.)