### PR TITLE
Use custom shouldComponentUpdateComparator when comparing props 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -139,7 +139,7 @@ abstract class ComponentBase<P extends React.Props<any>, S extends Object> exten
             }
         });
 
-        if (!_.isEqual(this.props, nextProps)) {
+        if (!Options.shouldComponentUpdateComparator(this.props, nextProps)) {
             let newState = this._buildStateWithAutoSubscriptions(nextProps, false);
             if (newState && !_.isEmpty(newState)) {
                 this.setState(newState);


### PR DESCRIPTION
before setstate instead of _.isEqual

This allows the same logic that compares props in shouldComponentUpdate to be used to determine if we should trigger a new buildState