### PR TITLE
Added Performance API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /src/obj
 *.user
 /ReSubTestsPack.js
+npm-debug.log

--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -12,6 +12,7 @@ import assert = require('assert');
 import _ = require('./lodashMini');
 import React = require('react');
 
+import Instrumentation from './Instrumentation';
 import Options from './Options';
 import { AutoSubscription, StoreBase } from './StoreBase';
 import { enableAutoSubscribe, enableAutoSubscribeWrapper, forbidAutoSubscribeWrapper } from './AutoSubscriptions';
@@ -185,7 +186,7 @@ export abstract class ComponentBase<P extends React.Props<any>, S extends Object
                 return undefined;
             }
         }
-            
+
         let nsubscription: StoreSubscriptionInternal<S> = _.extend(subscription, {
             // Wrap the given callback (if any) to provide extra functionality.
             _callback: subscription.callbackBuildState
@@ -397,7 +398,10 @@ export abstract class ComponentBase<P extends React.Props<any>, S extends Object
             sub.used = false;
         });
 
+        Instrumentation.beginBuildState();
         const state = this._buildState(props, initialBuild);
+        Instrumentation.endBuildState(this.constructor);
+
         _.remove(this._handledAutoSubscriptions, subscription => {
             if (this._shouldRemoveAndCleanupAutoSubscription(subscription)) {
                 subscription.store.removeAutoSubscription(subscription);

--- a/src/Instrumentation.ts
+++ b/src/Instrumentation.ts
@@ -1,0 +1,69 @@
+/**
+* Instrumentation.ts
+* Author: Lukas Weber
+* Copyright: Microsoft 2017
+*
+*/
+
+import _ = require('./lodashMini');
+
+import Options from './Options';
+
+export interface Performance {
+    mark: (name: string) => void;
+    measure: (name: string, startMark: string, endMark: string) => void;
+}
+
+function getPerformanceImpl(): Performance {
+    const { performance } = (global || window || {}) as any;
+
+    if (performance && performance.mark && performance.measure) {
+        return performance;
+    }
+
+    return {
+        mark: _.noop,
+        measure: _.noop,
+    };
+}
+
+const BuildStateBeginMark = 'ComponentBase._buildState begin';
+const BuildStateEndMark = 'ComponentBase._buildState end';
+const CallbackBeginMark = 'StoreBase callbacks begin';
+const CallbackEndMark = 'StoreBase callbacks end';
+
+// replace method implementation with noop outside of development mode
+function devOnly(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    if (!Options.development && descriptor) {
+        descriptor.value = _.noop;
+    }
+}
+
+export class Instrumentation {
+    constructor(private performance = getPerformanceImpl()) {
+    }
+
+    @devOnly
+    beginBuildState() {
+        this.performance.mark(BuildStateBeginMark);
+    }
+
+    @devOnly
+    endBuildState(target: any) {
+        this.performance.mark(BuildStateEndMark);
+        this.performance.measure(`🌀 ${target.name || 'ComponentBase'} callback`, BuildStateBeginMark, BuildStateEndMark);
+    }
+
+    @devOnly
+    beginStoreCallback() {
+        this.performance.mark(CallbackBeginMark);
+    }
+
+    @devOnly
+    endStoreCallback(target: any) {
+        this.performance.mark(CallbackEndMark);
+        this.performance.measure(`📦 ${target.name || 'StoreBase'} callback`, CallbackBeginMark, CallbackEndMark);
+    }
+}
+
+export default new Instrumentation;

--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -14,6 +14,7 @@
 import _ = require('./lodashMini');
 import assert = require('assert');
 
+import Instrumentation from './Instrumentation';
 import MapShim from './MapShim';
 import Options from './Options';
 import { SubscriptionCallbackFunction } from './Types';
@@ -219,7 +220,9 @@ export abstract class StoreBase {
             // Do a quick dedupe on keys
             const uniquedKeys = keys ? _.uniq(keys) : keys;
             // Convert null key (meaning "all") to undefined for the callback.
+            Instrumentation.beginStoreCallback();
             callback(uniquedKeys || undefined);
+            Instrumentation.endStoreCallback(this.constructor);
         });
         this._isTriggering = false;
 


### PR DESCRIPTION
StoreBase callbacks and _buildState()s are shown on user timing
timeline along with React 16.0+

It's supported on Web/Electron and while remote debugging RN
with Chrome(v8). Needs Performance.mark() and Performance.measure() 
to be present to work, otherwise it uses noop implementation.

<img width="736" alt="timing" src="https://user-images.githubusercontent.com/546887/33510281-9682a0a8-d70a-11e7-8c88-dd18e777bc46.png">