### PR TITLE
1.0.4: Option to disable "catch in render -> null".

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -15,6 +15,10 @@ export interface IOptions {
 
     shouldComponentUpdateComparator: <T>(values: T, compareTo: T) => boolean;
 
+    // Default behavior is to try/catch in render and unmount if there was an exception. However, the new React error boundaries
+    // makes this redundant. Set to false to disable our extra try/catch behavior.
+    preventTryCatchInRender: boolean;
+
     // Enables development mode -- more run-time checks.  By default, matches the NODE_ENV environment variable -- only set to true when
     // NODE_ENV is set and is set to something other than "production".
     development: boolean;
@@ -30,6 +34,8 @@ let OptionsVals: IOptions = {
     clearTimeout: clearTimeout.bind(null),
 
     shouldComponentUpdateComparator: _.isEqual.bind(_),
+
+    preventTryCatchInRender: false,
 
     development: typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production'
 };


### PR DESCRIPTION
React error boundaries will make this redundant.