### PR TITLE
Added withStoreSubscription, an HOC-form of ComponentBase.

### DIFF
--- a/examples/counter/src/Counter.tsx
+++ b/examples/counter/src/Counter.tsx
@@ -19,9 +19,8 @@ export class Counter extends ComponentBase<ICounterProps, ICounterState> {
   public render(): ReactElement<any> {
     return (
       <>
-        <div>
-          <h1>{ this.state.counter }</h1>
-        </div>
+        <h1>{ this.state.counter }</h1>
+        <p>(using Counter)</p>
 
         <div>
           <button onClick={() => CounterStore.increment()}>+</button>

--- a/examples/counter/src/CounterWithStoreSubscription.tsx
+++ b/examples/counter/src/CounterWithStoreSubscription.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react';
 import { ComponentBase, withStoreSubscription } from 'resub';
 import CounterStore from './Counter.store';
 
-type ICounterSFCProps = React.Props<any> & {
+interface ICounterSFCProps {
   counter: number;
 };
 
@@ -20,6 +20,6 @@ const CounterSFC = ({ counter }: ICounterSFCProps) => (
   </>
 );
 
-export default withStoreSubscription<{}, {}>(() => ({
-    counter: CounterStore.getCounter(),
+export default withStoreSubscription<{}, ICounterSFCProps>(() => ({
+    counter: CounterStore.getCounter()
 }))(CounterSFC);

--- a/examples/counter/src/CounterWithStoreSubscription.tsx
+++ b/examples/counter/src/CounterWithStoreSubscription.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { ReactElement } from 'react';
+import { ComponentBase, withStoreSubscription } from 'resub';
+import CounterStore from './Counter.store';
+
+type ICounterSFCProps = React.Props<any> & {
+  counter: number;
+};
+
+const CounterSFC = ({ counter }: ICounterSFCProps) => (
+  <>
+    <h1>{ counter }</h1>
+    <p>(using CounterWithStoreSubscription)</p>
+
+    <div>
+      <button onClick={() => CounterStore.increment()}>+</button>
+      <button onClick={() => CounterStore.decrement()}>-</button>
+      <button onClick={() => CounterStore.reset()}>Reset</button>
+    </div>
+  </>
+);
+
+export default withStoreSubscription<{}, {}>(() => ({
+    counter: CounterStore.getCounter(),
+}))(CounterSFC);

--- a/examples/counter/src/index.tsx
+++ b/examples/counter/src/index.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Counter } from './Counter';
+import CounterWithStoreSubscription from './CounterWithStoreSubscription';
 
 ReactDOM.render(
-  <Counter />,
+  <>
+    <Counter />
+    <CounterWithStoreSubscription />
+  </>,
   document.getElementById('root'),
 );

--- a/src/ReSub.ts
+++ b/src/ReSub.ts
@@ -7,12 +7,14 @@
 */
 
 import ComponentBaseI = require('./ComponentBase');
+import withStoreSubscriptionI = require('./withStoreSubscription');
 import AutoSubscriptionsI = require('./AutoSubscriptions');
 import StoreBaseI = require('./StoreBase');
 import TypesI = require('./Types');
 import OptionsI = require('./Options');
 
 export const ComponentBase = ComponentBaseI.ComponentBase;
+export const withStoreSubscription = withStoreSubscriptionI.withStoreSubscription;
 
 export const StoreBase = StoreBaseI.StoreBase;
 

--- a/src/withStoreSubscription.tsx
+++ b/src/withStoreSubscription.tsx
@@ -1,0 +1,37 @@
+/**
+* withStoreSubscription.ts
+* Author: Brent Traut
+* Copyright: Microsoft 2017
+*
+* withStoreSubscription is a HOC that tries to reduce the store subscription boilerplate
+* code. It moves autosubscription values out of state and into props by inserting an extra
+* container component.
+*
+* Create a wrapper factory by passing a buildState function into withStoreSubscription.
+* Then pass dumb components into the wrapper factory to wrap them with autosubscribed
+* container components that leverage the given buildState method.
+*/
+
+'use strict';
+
+import * as React from 'react';
+import ComponentBase from './ComponentBase';
+
+export function withStoreSubscription<
+    WrapperProps extends React.Props<any>,
+    State extends Object
+>(buildState: (props?: WrapperProps, initialBuild?: boolean) => State) {
+    return (Subject: React.ComponentClass<WrapperProps & State> | React.SFC<WrapperProps & State>) => {
+        return class WithStoreSubscription extends ComponentBase<WrapperProps, State> {
+            protected _buildState(props: WrapperProps, initialBuild: boolean) {
+                return buildState.apply(this, arguments);
+            }
+
+            public displayName = `WithSubscription(${Subject.displayName || 'Component'}`;
+
+            public render() {
+                return <Subject {...(this.props || {}) as any} {...(this.state || {}) as any} />;
+            }
+        } as React.ComponentClass<WrapperProps>;
+    };
+}

--- a/src/withStoreSubscription.tsx
+++ b/src/withStoreSubscription.tsx
@@ -1,7 +1,7 @@
 /**
 * withStoreSubscription.ts
 * Author: Brent Traut
-* Copyright: Microsoft 2017
+* Copyright: Microsoft 2018
 *
 * withStoreSubscription is a HOC that tries to reduce the store subscription boilerplate
 * code. It moves autosubscription values out of state and into props by inserting an extra
@@ -11,8 +11,6 @@
 * Then pass dumb components into the wrapper factory to wrap them with autosubscribed
 * container components that leverage the given buildState method.
 */
-
-'use strict';
 
 import * as React from 'react';
 import ComponentBase from './ComponentBase';
@@ -30,7 +28,7 @@ export function withStoreSubscription<
             public displayName = `WithSubscription(${Subject.displayName || 'Component'}`;
 
             public render() {
-                return <Subject {...(this.props || {}) as any} {...(this.state || {}) as any} />;
+                return <Subject {...(this.props || {})} {...(this.state || {})} />;
             }
         } as React.ComponentClass<WrapperProps>;
     };


### PR DESCRIPTION
One of the concerns I've had with ReSub since learning more about common industry patterns is that components tend do have lots of mixed logic and presentation. Using the HOC pattern allows for easy separation into container components (with subscriptions) and visual components that may or may not use state for their own concerns. This makes components more reusable and testable and potentially reduces re-renders and data fetching in some cases.

See the updated "counter" example for usage. If y'all like the code, I'll follow up with docs.