### PR TITLE
 Remove useless 'use strict'. ts compiler uses 'strict: true' which enables 'alwaysStrict'

### DIFF
--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -6,8 +6,6 @@
 * Base class for React components, adding in support for automatic store registration and unregistration.
 */
 
-'use strict';
-
 import assert = require('assert');
 import _ = require('./lodashMini');
 import React = require('react');


### PR DESCRIPTION
> Enabling --strict enables --noImplicitAny, --noImplicitThis, --alwaysStrict, --strictNullChecks, --strictFunctionTypes and --strictPropertyInitialization.

> --alwaysStrict - Parse in strict mode and emit "use strict" for each source file