### PR TITLE
Reduce memory usage in library by removing _.bind usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -140,7 +140,7 @@ export function enableAutoSubscribeWrapper<T extends Function>(handler: AutoSubs
 // Returns a new function that warns if any auto-subscriptions would have been encountered.
 export function forbidAutoSubscribeWrapper<T extends () => any>(existingMethod: T, thisArg?: any): T {
     if (!Options.development) {
-        return thisArg ? <T><any>_.bind(existingMethod, thisArg) : existingMethod;
+        return thisArg ? existingMethod.bind(thisArg) : existingMethod;
     }
     return createAutoSubscribeWrapper(undefined, AutoOptions.Forbid, existingMethod, thisArg);
 }

--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -200,7 +200,7 @@ export abstract class ComponentBase<P extends React.Props<any>, S extends Object
                     ? (keys?: string[]) => { subscription.callback!!!(keys); }
                     // Callback was not given.
                     : undefined,
-            _lambda: _.bind(this._onSubscriptionChanged, this, subscription),
+            _lambda: this._onSubscriptionChanged.bind(this, subscription),
             _id: ComponentBase._nextSubscriptionId++
         });
 


### PR DESCRIPTION
Turns out _.bind stringifies the input function and staples onto toString, which can cause un-wanted memory usage