### PR TITLE
Remove lodash.bind from Options.ts

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -33,7 +33,7 @@ let OptionsVals: IOptions = {
     setTimeout: setTimeout.bind(null),
     clearTimeout: clearTimeout.bind(null),
 
-    shouldComponentUpdateComparator: _.isEqual.bind(_),
+    shouldComponentUpdateComparator: (a, b) => _.isEqual(a, b),
 
     preventTryCatchInRender: false,
 

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -30,8 +30,8 @@ interface IProcess {
 declare var process: IProcess;
 
 let OptionsVals: IOptions = {
-    setTimeout: setTimeout.bind(null),
-    clearTimeout: clearTimeout.bind(null),
+    setTimeout: (...args) => setTimeout(...args),
+    clearTimeout: (...args) => clearTimeout(...args),
 
     shouldComponentUpdateComparator: (a, b) => _.isEqual(a, b),
 

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -30,10 +30,10 @@ interface IProcess {
 declare var process: IProcess;
 
 let OptionsVals: IOptions = {
-    setTimeout: (...args) => setTimeout(...args),
-    clearTimeout: (...args) => clearTimeout(...args),
+    setTimeout: (...args: any[]) => setTimeout(...args),
+    clearTimeout: (...args: any[]) => clearTimeout(...args),
 
-    shouldComponentUpdateComparator: (a, b) => _.isEqual(a, b),
+    shouldComponentUpdateComparator: (a: any, b: any) => _.isEqual(a, b),
 
     preventTryCatchInRender: false,
 


### PR DESCRIPTION
`lodash.bind` calls `Function.prototype.toString` which makes Chakra (the JS engine on UWP) map the entire JS bundle into memory. it's interesting that fixing just the `_.isEqual` line here isn't enough to remove the allocation.

Issue #76