### PR TITLE
feature/remove unused lodash helpers

### DIFF
--- a/src/lodashMini.ts
+++ b/src/lodashMini.ts
@@ -7,9 +7,7 @@
 * Imports a subset of lodash library needed for ReSub
 */
 
-import isUndefined from 'lodash/isUndefined';
 import isFunction from 'lodash/isFunction';
-import findIndex from 'lodash/findIndex';
 import isString from 'lodash/isString';
 import uniqueId from 'lodash/uniqueId';
 import isNumber from 'lodash/isNumber';
@@ -38,9 +36,7 @@ interface Dictionary<T> {
 
 export {
     Dictionary,
-    isUndefined,
     isFunction,
-    findIndex,
     isString,
     uniqueId,
     isNumber,

--- a/src/lodashMini.ts
+++ b/src/lodashMini.ts
@@ -24,7 +24,6 @@ import remove from 'lodash/remove';
 import values from 'lodash/values';
 import clone from 'lodash/clone';
 import union from 'lodash/union';
-import some from 'lodash/some';
 import uniq from 'lodash/uniq';
 import pull from 'lodash/pull';
 import find from 'lodash/find';
@@ -56,7 +55,6 @@ export {
     values,
     clone,
     union,
-    some,
     uniq,
     pull,
     find,


### PR DESCRIPTION
Basically, this issue which I described here, [ReactXP/970](https://github.com/Microsoft/reactxp/issues/970). In the future better to move away from _lodashMini_. 