### PR TITLE
use native .slice method to copy array

### DIFF
--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -172,9 +172,10 @@ export abstract class StoreBase {
             throttledUntil: number | undefined, bypassBlock: boolean): void {
         const existingMeta = StoreBase._pendingCallbacks.get(callback);
         StoreBase._updateExistingMeta(existingMeta, throttledUntil, bypassBlock);
+
         if (existingMeta === undefined) {
             // We need to clone keys in order to prevent accidental by-ref mutations
-            StoreBase._pendingCallbacks.set(callback, { keys: _.clone(keys), throttledUntil, bypassBlock });
+            StoreBase._pendingCallbacks.set(callback, { keys: [...keys], throttledUntil, bypassBlock });
         } else if (existingMeta.keys === null) {
             // Do nothing since it's already an all-key-trigger
         } else {

--- a/src/lodashMini.ts
+++ b/src/lodashMini.ts
@@ -19,7 +19,6 @@ import indexOf from 'lodash/indexOf';
 import extend from 'lodash/extend';
 import remove from 'lodash/remove';
 import values from 'lodash/values';
-import clone from 'lodash/clone';
 import union from 'lodash/union';
 import uniq from 'lodash/uniq';
 import pull from 'lodash/pull';
@@ -46,7 +45,6 @@ export {
     extend,
     remove,
     values,
-    clone,
     union,
     uniq,
     pull,


### PR DESCRIPTION
`keys` is the array of strings. To copy array we can use some of native methods, like [`.slice`, `[...]` which a little bit faster than  `_.clone`](https://jsfiddle.net/arv1jek7/).