### PR TITLE
Add the ability to specify comparators for ReSub components via Decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ ReSub’s implementation of this method always returns true, which is inline wit
 1) Override `shouldComponentUpdate` in specific components and *don't* call super
 1) Apply a decorator to specific component classes to apply default or custom shouldComponentUpdate comparators:
     * `@DeepEqualityShouldComponentUpdate` - This will do a deep equality check (`_.isEqual`) on Props, State & Context and return `true` from `shouldComponentUpdate` if any of the values have changed
-    * `CustomEqualityShouldComponentUpdate(myComparatorFunctino)` - This will call you custom comparator function (for Props, State and Context), returning `true` from `shouldComponentUpdate` if your comparator returns false.
+    * `@CustomEqualityShouldComponentUpdate(myComparatorFunction)` - This will call your custom comparator function (for Props, State and Context), returning `true` from `shouldComponentUpdate` if your comparator returns false.
 
 *Note: `_.isEqual` is a deep comparison operator, and hence can cause performance issues with deep data structures.*
 

--- a/README.md
+++ b/README.md
@@ -204,9 +204,13 @@ Returns true if the component is currently mounted, false otherwise. Subclasses 
 
 ##### `shouldComponentUpdate(nextProps: P, nextState: S): boolean`
 
-This method is provided by ReSub already, but can be overridden. Subclasses that override it do not need to call super.
+ReSub’s implementation of this method always returns true, which is inline with React's guidance.  If you wish to apply optimizations using `shouldComponentUpdate` we provide a few different methods to do this:
 
-ReSub’s implementation of this method uses `_.isEqual` to compare new state and props with their previous values and returns true if a change is found.
+1) Provide a `shouldComponentUpdateComparator` to the ReSub `Options` payload. This is the default comparator that is used in `shouldComponentUpdate` for components that extend `ComponentBase`. This is a good way to apply custom `shouldComponentUpdate` logic to all your components.
+1) Override `shouldComponentUpdate` in specific components and *don't* call super
+1) Apply a decorator to specific component classes to apply default or custom shouldComponentUpdate comparators:
+    * `@DeepEqualityShouldComponentUpdate` - This will do a deep equality check (`_.isEqual`) on Props, State & Context and return `true` from `shouldComponentUpdate` if any of the values have changed
+    * `CustomEqualityShouldComponentUpdate(myComparatorFunctino)` - This will call you custom comparator function (for Props, State and Context), returning `true` from `shouldComponentUpdate` if your comparator returns false.
 
 *Note: `_.isEqual` is a deep comparison operator, and hence can cause performance issues with deep data structures.*
 

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -66,7 +66,6 @@ import * as Decorator from './Decorator';
 import Options from './Options';
 import { assert } from './utils';
 import { StoreBase } from './StoreBase';
-import ComponentBase from './ComponentBase';
 
 type MetadataIndex = {
     [methodName: string]: MetadataIndexData
@@ -211,24 +210,6 @@ export const AutoSubscribeStore: ClassDecorator = <TFunction extends Function>(f
 
     return func;
 };
-
-export function CustomEqualityShouldComponentUpdate<P extends React.Props<any>, S extends Object>(comparator: (this: ComponentBase<P, S>,
-        nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any) => boolean) {
-    return function <T extends { new(props: any): ComponentBase<P, S>}>(constructor: T): T {
-        constructor.prototype.shouldComponentUpdate = comparator;
-        return constructor;
-    };
-}
-
-export function DeepEqualityShouldComponentUpdate<T extends { new(props: any): ComponentBase<any, any> }>(constructor: T): T {
-    return CustomEqualityShouldComponentUpdate<any, any>(deepEqualityComparator)(constructor);
-}
-function deepEqualityComparator<P extends React.Props<any>, S extends Object>(this: ComponentBase<P, S>, nextProps: Readonly<P>,
-        nextState: Readonly<S>, nextContext: any): boolean {
-    return !_.isEqual(this.state, nextState) ||
-        !_.isEqual(this.props, nextProps) ||
-        !_.isEqual(this.context, nextContext);
-}
 
 // Triggers the handler of the most recent @enableAutoSubscribe method called up the call stack.
 function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues: string[]): MethodDecorator {

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -66,6 +66,7 @@ import * as Decorator from './Decorator';
 import Options from './Options';
 import { assert } from './utils';
 import { StoreBase } from './StoreBase';
+import ComponentBase from './ComponentBase';
 
 type MetadataIndex = {
     [methodName: string]: MetadataIndexData
@@ -210,6 +211,24 @@ export const AutoSubscribeStore: ClassDecorator = <TFunction extends Function>(f
 
     return func;
 };
+
+export function CustomEqualityShouldComponentUpdate<P extends React.Props<any>, S extends Object>(comparator: (this: ComponentBase<P, S>,
+        nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any) => boolean) {
+    return function <T extends { new(props: any): ComponentBase<P, S>}>(constructor: T): T {
+        constructor.prototype.shouldComponentUpdate = comparator;
+        return constructor;
+    };
+}
+
+export function DeepEqualityShouldComponentUpdate<T extends { new(props: any): ComponentBase<any, any> }>(constructor: T): T {
+    return CustomEqualityShouldComponentUpdate<any, any>(deepEqualityComparator)(constructor);
+}
+function deepEqualityComparator<P extends React.Props<any>, S extends Object>(this: ComponentBase<P, S>, nextProps: Readonly<P>,
+        nextState: Readonly<S>, nextContext: any): boolean {
+    return !_.isEqual(this.state, nextState) ||
+        !_.isEqual(this.props, nextProps) ||
+        !_.isEqual(this.context, nextContext);
+}
 
 // Triggers the handler of the most recent @enableAutoSubscribe method called up the call stack.
 function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues: string[]): MethodDecorator {

--- a/src/ComponentDecorators.ts
+++ b/src/ComponentDecorators.ts
@@ -1,0 +1,28 @@
+/**
+ * ComponentDecorators.ts
+ * Copyright: Microsoft 2019
+ *
+ * Exposes helper decorator functions for use with ReSub Components
+ */
+
+import * as _ from './lodashMini';
+import ComponentBase from './ComponentBase';
+
+export function CustomEqualityShouldComponentUpdate<P extends React.Props<any>, S extends Object>(comparator: (this: ComponentBase<P, S>,
+        nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any) => boolean) {
+    return function <T extends { new(props: any): ComponentBase<P, S>}>(constructor: T): T {
+        constructor.prototype.shouldComponentUpdate = comparator;
+        return constructor;
+    };
+}
+
+export function DeepEqualityShouldComponentUpdate<T extends { new(props: any): ComponentBase<any, any> }>(constructor: T): T {
+    return CustomEqualityShouldComponentUpdate<any, any>(deepEqualityComparator)(constructor);
+}
+
+function deepEqualityComparator<P extends React.Props<any>, S extends Object>(this: ComponentBase<P, S>, nextProps: Readonly<P>,
+        nextState: Readonly<S>, nextContext: any): boolean {
+    return !_.isEqual(this.state, nextState) ||
+        !_.isEqual(this.props, nextProps) ||
+        !_.isEqual(this.context, nextContext);
+}

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -35,7 +35,7 @@ let OptionsVals: IOptions = {
     setTimeout: setTimeout.bind(null),
     clearTimeout: clearTimeout.bind(null),
 
-    shouldComponentUpdateComparator: _.isEqual.bind(_),
+    shouldComponentUpdateComparator: () => true,
 
     defaultThrottleMs: 0,
 

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -35,7 +35,7 @@ let OptionsVals: IOptions = {
     setTimeout: setTimeout.bind(null),
     clearTimeout: clearTimeout.bind(null),
 
-    shouldComponentUpdateComparator: () => true,
+    shouldComponentUpdateComparator: () => false,
 
     defaultThrottleMs: 0,
 

--- a/src/ReSub.ts
+++ b/src/ReSub.ts
@@ -16,6 +16,7 @@ export {
     key,
 } from './AutoSubscriptions';
 export { ComponentBase } from './ComponentBase';
+export { CustomEqualityShouldComponentUpdate, DeepEqualityShouldComponentUpdate } from './ComponentDecorators';
 export { default as Options } from './Options';
 export { StoreBase } from './StoreBase';
 export { Types };

--- a/test/AutoSubscribe.spec.tsx
+++ b/test/AutoSubscribe.spec.tsx
@@ -7,11 +7,6 @@
  */
 
 import * as React from 'react';
-import ComponentBase from '../src/ComponentBase';
-import { SimpleStore, TriggerKeys, StoreData } from './SimpleStore';
-import { StoreBase } from '../src/StoreBase';
-import { mount, ReactWrapper } from 'enzyme';
-
 import {
     includes,
     cloneDeep,
@@ -20,7 +15,12 @@ import {
     each,
     uniq,
 } from 'lodash';
-import { DeepEqualityShouldComponentUpdate } from '../src/AutoSubscriptions';
+import { mount, ReactWrapper } from 'enzyme';
+
+import ComponentBase from '../src/ComponentBase';
+import { DeepEqualityShouldComponentUpdate } from '../src/ComponentDecorators';
+import { SimpleStore, TriggerKeys, StoreData } from './SimpleStore';
+import { StoreBase } from '../src/StoreBase';
 
 // Instance of the SimpleStore used throughout the test. Re-created for each test.
 let SimpleStoreInstance: SimpleStore;

--- a/test/SimpleStore.ts
+++ b/test/SimpleStore.ts
@@ -1,4 +1,3 @@
-import * as assert from 'assert';
 import { StoreBase } from '../src/StoreBase';
 import { isEqual, uniq } from 'lodash';
 import {
@@ -9,6 +8,7 @@ import {
     autoSubscribe,
     key,
 } from '../src/AutoSubscriptions';
+import { assert } from '../src/utils';
 
 export const enum TriggerKeys {
     First,
@@ -98,7 +98,7 @@ export class SimpleStore extends StoreBase {
     @disableWarnings
     protected _getSubscriptionKeys() {
         const keys = super._getSubscriptionKeys();
-        assert.deepEqual(keys, uniq(keys), 'Internal failure: StoreBase should not report duplicate keys');
+        assert(isEqual(keys, uniq(keys)), 'Internal failure: StoreBase should not report duplicate keys');
         return keys;
     }
 


### PR DESCRIPTION
Update README with new functionality
Additionally, follow React guidance and encourace consumers to optimize shouldComponentUpdate instead of doing deep equality checks on every update