### PR TITLE
Building in a system that supports compound keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,11 @@ class TodoList extends ComponentBase<TodoListProps, TodoListState> {
 
 Sometimes, either when a single store contains hierarchical data, or when you have more than one parameter to a function that you'd like to have key-based subscriptions to (i.e. a user and a name of an object that the user has), the single @key mechanism isn't good enough.  We've added the ability to put @key on multiple parameters to a function, and ReSub concatenates them with the `formCompoundKey` function (also exported by ReSub) to form the actual subscription key.  You can also combine this with @autoSubscribeWithKey to have even more hierarchy on your data.  Note that the @autoSubscribeWithKey value always goes on the _end_ of the compound key, since it should be the most selective part of your hierarchy.
 
-To trigger these compound keys, you execute `this.trigger(ReSub.formCompoundKey('key1val', 'key2val', 'autoSubscribeWithKeyval'))` and it will trigger the key to match the autosubscription of your function.  Example:
+To trigger these compound keys, you execute `this.trigger(ReSub.formCompoundKey('key1val', 'key2val', 'autoSubscribeWithKeyval'))` and it will trigger the key to match the autosubscription of your function.
+
+*NOTE:* Compound keys themselves don't actually support any sort of hierarchy.  If you don't trigger EXACTLY the correct key, your subscriptions will not update.  If you have a key of `['a', 'b', 'c']`, and you trigger `['a', 'b']`, you will be disappointed to find that none of your subscribed components update.  Compound keys are designed to help you provide discrete updates within a hierarchy of data, but are not designed to allow for updating wide swaths of that hierarchy.
+
+Example of correct usage:
 
 ```typescript
 enum TriggerKeys {

--- a/README.md
+++ b/README.md
@@ -176,6 +176,43 @@ class TodoList extends ComponentBase<TodoListProps, TodoListState> {
 
 `_buildState` will be called when `TodoStore` triggers any changes for the specified username, but not for any other usernames. This eliminates the need completely for any manual subscriptions to be made in `_initStoreSubscriptions`.
 
+#### Compound-key subscriptions/triggering
+
+Sometimes, either when a single store contains hierarchical data, or when you have more than one parameter to a function that you'd like to have key-based subscriptions to (i.e. a user and a name of an object that the user has), the single @key mechanism isn't good enough.  We've added the ability to put @key on multiple parameters to a function, and ReSub concatenates them with the `formCompoundKey` function (also exported by ReSub) to form the actual subscription key.  You can also combine this with @autoSubscribeWithKey to have even more hierarchy on your data.  Note that the @autoSubscribeWithKey value always goes on the _end_ of the compound key, since it should be the most selective part of your hierarchy.
+
+To trigger these compound keys, you execute `this.trigger(ReSub.formCompoundKey('key1val', 'key2val', 'autoSubscribeWithKeyval'))` and it will trigger the key to match the autosubscription of your function.  Example:
+
+```typescript
+enum TriggerKeys {
+    BoxA = 'a',
+    BoxB = 'b',
+}
+class UserStuffStore extends StoreBase {
+    private _stuffByUser: {[userCategory: string]: {[username: string]: {boxA: string; boxB: string;}}}
+
+    @autoSubscribeWithKey(TriggerKeys.BoxA)
+    getBoxAForUser(@key userCategory: string, @key username: string) {
+        return this._stuffByUser[userCategory][username].boxA;
+    }
+
+    @disableWarnings
+    setBoxAForUser(userCategory: string, username: string, boxAValue: string): void {
+        this._stuffByUser[userCategory][username].boxA = boxAValue;
+        this.trigger(ReSub.formCompoundKey(userCategory, username, TriggerKeys.BoxA));
+    }
+}
+
+class UserBoxADisplay extends ComponentBase<SomeProps, SomeState> {
+    ...
+
+    protected _buildState(props: SomeProps, initialBuild: boolean): TodoListState {
+        return {
+            boxA: UserStuffStore.getBoxAForUser(props.userCategory, props.username),
+        };
+    }
+}
+```
+
 #### Custom subscription callbacks:
 
 `StoreSubscriptions` created inside of `_initStoreSubscriptions` will call `_buildState` by default when they trigger. Instead, developers can specify a custom callback in `StoreSubscription` definitions using either `callbackBuildState` (with autosubscription support just like using `_buildState`) or `callback` (no autosubscription support):

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -64,7 +64,7 @@
 import * as _ from './lodashMini';
 import * as Decorator from './Decorator';
 import Options from './Options';
-import { assert, normalizeKeys, KeyOrKeys } from './utils';
+import { assert, normalizeKeys, KeyOrKeys, formCompoundKey } from './utils';
 import { StoreBase } from './StoreBase';
 
 type MetadataIndex = {
@@ -74,11 +74,11 @@ type MetadataIndex = {
 type MetadataIndexData = {
     hasAutoSubscribeDecorator?: boolean;
     hasIndex?: never;
-    index?: number
+    indexes?: number[];
 } | {
     hasAutoSubscribeDecorator?: boolean;
     hasIndex: true;
-    index: number
+    indexes: number[];
 };
 type MetadataProperties = { __decorated?: boolean; };
 type Metadata = MetadataIndex & MetadataProperties;
@@ -213,7 +213,7 @@ export const AutoSubscribeStore: ClassDecorator = <TFunction extends Function>(f
 };
 
 // Triggers the handler of the most recent @enableAutoSubscribe method called up the call stack.
-function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues: string[]): MethodDecorator {
+function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues?: string[]): MethodDecorator {
     return <T>(target: InstanceTarget, methodName: string|symbol, descriptor: TypedPropertyDescriptor<T>) => {
         const methodNameString = methodName.toString();
         const targetWithMetadata = instanceTargetToInstanceTargetWithMetadata(target);
@@ -245,28 +245,35 @@ function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues: string[])
                 return existingMethod.apply(this, args);
             }
 
-            // Let the handler know about this auto-subscriptions, then proceed to the existing method.
-
-            // Default to Key_All if no @key parameter.
-            let specificKeyValues = defaultKeyValues;
-
-            // Try to find an @key parameter in the target's metadata.
+            // Try to find an @key parameter in the target's metadata and form initial Key(s) from it/them.
+            let keyParamValues: (string | number)[] = [];
             if (metaForMethod.hasIndex) {
-                let keyArg: number | string = args[metaForMethod.index];
+                keyParamValues = metaForMethod.indexes.map(index => {
+                    let keyArg: number | string = args[index];
 
-                if (_.isNumber(keyArg)) {
-                    keyArg = keyArg.toString();
-                }
-
-                assert(keyArg, `@key parameter must be given a non-empty string or number: ` +
-                    `"${ methodNameString }"@${ metaForMethod.index } was given ${ JSON.stringify(keyArg) }`);
-
-                assert(_.isString(keyArg), `@key parameter must be given a string or number: ` +
-                    `"${ methodNameString }"@${ metaForMethod.index }`);
-
-                specificKeyValues = [keyArg];
+                    if (_.isNumber(keyArg)) {
+                        keyArg = keyArg.toString();
+                    }
+    
+                    assert(keyArg, `@key parameter must be given a non-empty string or number: ` +
+                        `"${ methodNameString }"@${ index } was given ${ JSON.stringify(keyArg) }`);
+    
+                    assert(_.isString(keyArg), `@key parameter must be given a string or number: ` +
+                        `"${ methodNameString }"@${ index }`);
+                    
+                    return keyArg;
+                });
             }
 
+            // Form a list of keys to trigger.
+            // If we have @key values, put them first, then append the @autosubscribewithkey key to the end.
+            // If there are multiple keys in the @autosubscribewithkey list, go through each one and do the
+            // same thing (@key then value).  If there's neither @key nor @autosubscribewithkey, it's Key_All.
+            const specificKeyValues: string[] = (defaultKeyValues && defaultKeyValues.length > 0) ?
+                _.map(defaultKeyValues, kv => formCompoundKey(...keyParamValues.concat(kv))) :
+                [(keyParamValues.length > 0) ? formCompoundKey(...keyParamValues) : StoreBase.Key_All];
+
+            // Let the handler know about this auto-subscriptions, then proceed to the existing method.
             let wasInAutoSubscribe: boolean;
             const result = _tryFinally(() => {
                 // Disable further auto-subscriptions if shallow.
@@ -295,9 +302,9 @@ function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues: string[])
     };
 }
 
-export const autoSubscribe = makeAutoSubscribeDecorator(true, [StoreBase.Key_All]);
+export const autoSubscribe = makeAutoSubscribeDecorator(true, undefined);
 export function autoSubscribeWithKey(keyOrKeys: KeyOrKeys) {
-    assert(keyOrKeys || _.isNumber(keyOrKeys), 'Must specify a key when using autoSubscribeWithKey');
+    assert(keyOrKeys !== undefined, 'Must specify a key when using autoSubscribeWithKey');
     return makeAutoSubscribeDecorator(true, normalizeKeys(keyOrKeys));
 }
 
@@ -309,10 +316,9 @@ export function key(target: InstanceTarget, methodName: string, index: number) {
     // Shorthand.
     const metaForMethod = getMethodMetadata(targetWithMetadata, methodName);
 
-    assert(!metaForMethod.hasIndex, `Can only apply @key once per method: only the first will be used "${ methodName }"@${ index }`);
-
-    // Save this parameter's index into the target's metadata.
-    metaForMethod.index = index;
+    // Save this parameter's index into the target's metadata.  Stuff it at the front since decorators
+    // seem to resolve in reverse order of arguments..?
+    metaForMethod.indexes = [index].concat(metaForMethod.indexes || []);
     metaForMethod.hasIndex = true;
 }
 

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -73,12 +73,7 @@ type MetadataIndex = {
 
 type MetadataIndexData = {
     hasAutoSubscribeDecorator?: boolean;
-    hasIndex?: never;
-    indexes?: number[];
-} | {
-    hasAutoSubscribeDecorator?: boolean;
-    hasIndex: true;
-    indexes: number[];
+    keyIndexes?: number[];
 };
 type MetadataProperties = { __decorated?: boolean; };
 type Metadata = MetadataIndex & MetadataProperties;
@@ -247,8 +242,8 @@ function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues?: string[]
 
             // Try to find an @key parameter in the target's metadata and form initial Key(s) from it/them.
             let keyParamValues: (string | number)[] = [];
-            if (metaForMethod.hasIndex) {
-                keyParamValues = metaForMethod.indexes.map(index => {
+            if (metaForMethod.keyIndexes) {
+                keyParamValues = metaForMethod.keyIndexes.map(index => {
                     let keyArg: number | string = args[index];
 
                     if (_.isNumber(keyArg)) {
@@ -304,7 +299,7 @@ function makeAutoSubscribeDecorator(shallow = false, defaultKeyValues?: string[]
 
 export const autoSubscribe = makeAutoSubscribeDecorator(true, undefined);
 export function autoSubscribeWithKey(keyOrKeys: KeyOrKeys) {
-    assert(keyOrKeys !== undefined, 'Must specify a key when using autoSubscribeWithKey');
+    assert(keyOrKeys || _.isNumber(keyOrKeys), 'Must specify a key when using autoSubscribeWithKey');
     return makeAutoSubscribeDecorator(true, normalizeKeys(keyOrKeys));
 }
 
@@ -318,8 +313,7 @@ export function key(target: InstanceTarget, methodName: string, index: number) {
 
     // Save this parameter's index into the target's metadata.  Stuff it at the front since decorators
     // seem to resolve in reverse order of arguments..?
-    metaForMethod.indexes = [index].concat(metaForMethod.indexes || []);
-    metaForMethod.hasIndex = true;
+    metaForMethod.keyIndexes = [index].concat(metaForMethod.keyIndexes || []);
 }
 
 export function disableWarnings<T extends Function>(target: InstanceTarget, methodName: string, descriptor: TypedPropertyDescriptor<T>) {

--- a/src/ReSub.ts
+++ b/src/ReSub.ts
@@ -20,3 +20,6 @@ export { CustomEqualityShouldComponentUpdate, DeepEqualityShouldComponentUpdate 
 export { default as Options } from './Options';
 export { StoreBase } from './StoreBase';
 export { Types };
+export {
+    formCompoundKey,
+} from './utils';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export const normalizeKeys = (keyOrKeys: KeyOrKeys): string[] => (
 );
 
 export const formCompoundKey = (...keys: (string | number)[]): string => {
-    return keys.map(k => k.toString()).join(CompoundKeyJoinerString);
+    return keys.join(CompoundKeyJoinerString);
 };
 
 export const assert = (cond: any, message?: string | undefined) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,8 @@
  */
 import { map } from './lodashMini';
 
+const CompoundKeyJoinerString = '%&';
+
 export type KeyOrKeys = string | number | (string | number)[];
 
 export const normalizeKey = (key: string | number): string => (
@@ -13,6 +15,10 @@ export const normalizeKey = (key: string | number): string => (
 export const normalizeKeys = (keyOrKeys: KeyOrKeys): string[] => (
     map(Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys], normalizeKey)
 );
+
+export const formCompoundKey = (...keys: (string | number)[]): string => {
+    return keys.map(k => k.toString()).join(CompoundKeyJoinerString);
+};
 
 export const assert = (cond: any, message?: string | undefined) => {
     if (!cond) {

--- a/test/AutoSubscribe.spec.tsx
+++ b/test/AutoSubscribe.spec.tsx
@@ -97,11 +97,11 @@ class SimpleComponent extends ComponentBase<SimpleProps, SimpleState> {
         } else if (props.test_enumKeyedSub) {
             newState.keyedDataSum = SimpleStoreInstance.getDataSingleEnumKeyed() + SimpleStoreInstance.getDataMultiEnumKeyed();
         } else if (props.test_compoundSingleKeySub) {
-            newState.keyedDataSum = SimpleStoreInstance.getSingleKeySingleASKey(props.ids[0]) +
-                SimpleStoreInstance.getSingleKeyMultiASKey(props.ids[0]);
+            newState.keyedDataSum = SimpleStoreInstance.getSingleKeySingleAutoSubKey(props.ids[0]) +
+                SimpleStoreInstance.getSingleKeyMultiAutoSubKey(props.ids[0]);
         } else if (props.test_compoundMultiKeySub) {
-            newState.keyedDataSum = SimpleStoreInstance.getMultiKeySingleASKey(props.ids[0], props.ids[1]) +
-                SimpleStoreInstance.getMultiKeyMultiASKey(props.ids[0], props.ids[1]);
+            newState.keyedDataSum = SimpleStoreInstance.getMultiKeySingleAutoSubKey(props.ids[0], props.ids[1]) +
+                SimpleStoreInstance.getMultiKeyMultiAutoSubKey(props.ids[0], props.ids[1]);
         }
 
         newState.storeDatas = props.ids.map(id => SimpleStoreInstance.getStoreData(id));
@@ -435,6 +435,10 @@ describe('AutoSubscribe', function () {
         expect(Component.state('stateChanges')).toEqual(expectedState);
         SimpleStoreInstance.setStoreData('a', TriggerKeys.First.toString(), 1);
         expect(Component.state('stateChanges')).toEqual(expectedState);
+
+        // Triggering keys out of order also shouldn't work
+        SimpleStoreInstance.setStoreData('a', formCompoundKey(TriggerKeys.First, 'a'), 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
     });
 
     it('autoSubscribeWithKey and key - test multi-@key compound key Subscriptions', () => {
@@ -469,6 +473,12 @@ describe('AutoSubscribe', function () {
         expect(Component.state('stateChanges')).toEqual(expectedState);
         SimpleStoreInstance.setStoreData('a', formCompoundKey('a', 'b'), 1);
         expect(Component.state('stateChanges')).toEqual(expectedState);
+
+        // Triggering keys out of order also shouldn't work
+        SimpleStoreInstance.setStoreData('a', formCompoundKey('b', 'a', TriggerKeys.First), 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
+        SimpleStoreInstance.setStoreData('a', formCompoundKey(TriggerKeys.First, 'a', 'b'), 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
     });
 
     it('Manual Subscription triggers', () => {
@@ -483,6 +493,12 @@ describe('AutoSubscribe', function () {
             SimpleStoreInstance.unsubscribe(subToken2);
         });
         SimpleStoreInstance.setStoreDataForEnumKeyedSubscription(TriggerKeys.Second, 1);
+
+        const subToken3 = SimpleStoreInstance.subscribe(keys => {
+            expect(keys).toEqual([formCompoundKey('a', 'b')]);
+            SimpleStoreInstance.unsubscribe(subToken3);
+        });
+        SimpleStoreInstance.triggerArbitraryKey(formCompoundKey('a', 'b'));
     });
 
     it('Equality decorator override', () => {

--- a/test/AutoSubscribe.spec.tsx
+++ b/test/AutoSubscribe.spec.tsx
@@ -367,6 +367,10 @@ describe('AutoSubscribe', function () {
         SimpleStoreInstance.setStoreDataForKeyedSubscription('A', 3);
         expect(Component.state('stateChanges')).toEqual(++expectedState);
         expect(Component.state('keyedDataSum')).toEqual(13);
+
+        // Showing that you can't use a compound key as a multi-trigger
+        SimpleStoreInstance.triggerArbitraryKey(formCompoundKey('A', 'B'));
+        expect(Component.state('stateChanges')).toEqual(expectedState);
     });
 
     it('autoSubscribeWithKey does not trigger _buildState on other subscription change', () => {
@@ -378,6 +382,10 @@ describe('AutoSubscribe', function () {
         SimpleStoreInstance.setStoreData('foo', 'foo', 77);
         expect(Component.state('stateChanges')).toEqual(expectedState);
         expect(Component.state('keyedDataSum')).toEqual(9);
+
+        // Showing that you can't use a compound key as a multi-trigger either
+        SimpleStoreInstance.triggerArbitraryKey(formCompoundKey('A', 'B'));
+        expect(Component.state('stateChanges')).toEqual(expectedState);
     });
 
     it('autoSubscribeWithKey - test Enum Keyed Subscriptions', () => {
@@ -414,6 +422,19 @@ describe('AutoSubscribe', function () {
         SimpleStoreInstance.setStoreData('a', formCompoundKey('a', TriggerKeys.First), 1);
         expect(Component.state('stateChanges')).toEqual(++expectedState);
         expect(Component.state('keyedDataSum')).toEqual(5);
+
+        // This will still trigger a single state update, but will change nothing
+        SimpleStoreInstance.triggerArbitraryKey(undefined);
+        expect(Component.state('stateChanges')).toEqual(++expectedState);
+        expect(Component.state('keyedDataSum')).toEqual(5);
+
+        // None of these keys should trigger any subscription changes
+        SimpleStoreInstance.setStoreData('a', 'a', 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
+        SimpleStoreInstance.setStoreData('a', 'b', 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
+        SimpleStoreInstance.setStoreData('a', TriggerKeys.First.toString(), 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
     });
 
     it('autoSubscribeWithKey and key - test multi-@key compound key Subscriptions', () => {
@@ -433,6 +454,21 @@ describe('AutoSubscribe', function () {
         SimpleStoreInstance.setStoreData('a', formCompoundKey('a', 'b', TriggerKeys.First), 1);
         expect(Component.state('stateChanges')).toEqual(++expectedState);
         expect(Component.state('keyedDataSum')).toEqual(11);
+
+        // This will still trigger a single state update, but will change nothing
+        SimpleStoreInstance.triggerArbitraryKey(undefined);
+        expect(Component.state('stateChanges')).toEqual(++expectedState);
+        expect(Component.state('keyedDataSum')).toEqual(11);
+
+        // None of these keys should trigger any subscription changes
+        SimpleStoreInstance.setStoreData('a', 'a', 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
+        SimpleStoreInstance.setStoreData('a', 'b', 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
+        SimpleStoreInstance.setStoreData('a', TriggerKeys.First.toString(), 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
+        SimpleStoreInstance.setStoreData('a', formCompoundKey('a', 'b'), 1);
+        expect(Component.state('stateChanges')).toEqual(expectedState);
     });
 
     it('Manual Subscription triggers', () => {

--- a/test/AutoSubscribeWarnings.spec.tsx
+++ b/test/AutoSubscribeWarnings.spec.tsx
@@ -13,7 +13,7 @@ describe('AutoSubscribeWarnings', () => {
         class Component extends ComponentBase<{}, {}> {
             protected _buildState() {
                 // Test implementation detail: makes sure to use a method that will cause a warning (e.g. a setter).
-                expect(() => store.setStoreData(WARN_IN_BUILD_STATE, 1)).toThrowError(WARNING_MESSAGE);
+                expect(() => store.setStoreData(WARN_IN_BUILD_STATE, WARN_IN_BUILD_STATE, 1)).toThrowError(WARNING_MESSAGE);
                 return {};
             }
 

--- a/test/SimpleStore.ts
+++ b/test/SimpleStore.ts
@@ -8,7 +8,7 @@ import {
     autoSubscribe,
     key,
 } from '../src/AutoSubscriptions';
-import { assert } from '../src/utils';
+import { assert, formCompoundKey } from '../src/utils';
 
 export const enum TriggerKeys {
     First,
@@ -65,9 +65,35 @@ export class SimpleStore extends StoreBase {
         return this._subscribeWithEnumKeyData[TriggerKeys.First] + this._subscribeWithEnumKeyData[TriggerKeys.Second];
     }
 
+    @autoSubscribeWithKey(TriggerKeys.First)
+    getSingleKeySingleASKey(@key id: string): number {
+        return this._get(id) + this._subscribeWithEnumKeyData[TriggerKeys.First];
+    }
+
+    @autoSubscribeWithKey([TriggerKeys.First, TriggerKeys.Second])
+    getSingleKeyMultiASKey(@key id: string): number {
+        return this._get(id) + this._subscribeWithEnumKeyData[TriggerKeys.First] + this._subscribeWithEnumKeyData[TriggerKeys.Second];
+    }
+
+    @autoSubscribeWithKey(TriggerKeys.First)
+    getMultiKeySingleASKey(@key id: string, @key id2: string): number {
+        return this._get(id) + this._get(id2) + this._subscribeWithEnumKeyData[TriggerKeys.First];
+    }
+
+    @autoSubscribeWithKey([TriggerKeys.First, TriggerKeys.Second])
+    getMultiKeyMultiASKey(@key id: string, @key id2: string): number {
+        return this._get(id) + this._get(id2) +
+            this._subscribeWithEnumKeyData[TriggerKeys.First] + this._subscribeWithEnumKeyData[TriggerKeys.Second];
+    }
+
     setStoreDataForKeyedSubscription(key: 'A'|'B', data: number): void {
         this._subscribeWithKeyData[key] = data;
         this.trigger(key);
+    }
+
+    setStoreDataForCompoundEnumKeyedSubscription(idOrIds: string[], key: TriggerKeys, data: number): void {
+        this._subscribeWithEnumKeyData[key] = data;
+        this.trigger(formCompoundKey(...idOrIds, key));
     }
 
     setStoreDataForEnumKeyedSubscription(key: TriggerKeys, data: number): void {
@@ -85,12 +111,12 @@ export class SimpleStore extends StoreBase {
     // Note: explicitly adding decorator so the tests always works, even outside of debug mode. This is not necessary
     // in real stores, as explained above clearStoreData.
     @warnIfAutoSubscribeEnabled
-    setStoreData(id: string, storeData: StoreData) {
+    setStoreData(id: string, triggerKey: string, storeData: StoreData) {
         const old = this._storeDataById[id];
         this._storeDataById[id] = storeData;
 
         if (!isEqual(old, storeData)) {
-            this.trigger(id);
+            this.trigger(triggerKey);
         }
     }
 

--- a/test/SimpleStore.ts
+++ b/test/SimpleStore.ts
@@ -101,6 +101,11 @@ export class SimpleStore extends StoreBase {
         this.trigger(key);
     }
 
+    @disableWarnings
+    triggerArbitraryKey(key: string | number | undefined): void {
+        this.trigger(key);
+    }
+
     // Setters should not be called when auto-subscribe is enabled.
     // Note: @warnIfAutoSubscribeEnabled is automatically added (in debug mode) to any method missing @autoSubscribe
     // or @disableWarnings. That will catch the case where setters are called in a _buildState.

--- a/test/SimpleStore.ts
+++ b/test/SimpleStore.ts
@@ -66,22 +66,22 @@ export class SimpleStore extends StoreBase {
     }
 
     @autoSubscribeWithKey(TriggerKeys.First)
-    getSingleKeySingleASKey(@key id: string): number {
+    getSingleKeySingleAutoSubKey(@key id: string): number {
         return this._get(id) + this._subscribeWithEnumKeyData[TriggerKeys.First];
     }
 
     @autoSubscribeWithKey([TriggerKeys.First, TriggerKeys.Second])
-    getSingleKeyMultiASKey(@key id: string): number {
+    getSingleKeyMultiAutoSubKey(@key id: string): number {
         return this._get(id) + this._subscribeWithEnumKeyData[TriggerKeys.First] + this._subscribeWithEnumKeyData[TriggerKeys.Second];
     }
 
     @autoSubscribeWithKey(TriggerKeys.First)
-    getMultiKeySingleASKey(@key id: string, @key id2: string): number {
+    getMultiKeySingleAutoSubKey(@key id: string, @key id2: string): number {
         return this._get(id) + this._get(id2) + this._subscribeWithEnumKeyData[TriggerKeys.First];
     }
 
     @autoSubscribeWithKey([TriggerKeys.First, TriggerKeys.Second])
-    getMultiKeyMultiASKey(@key id: string, @key id2: string): number {
+    getMultiKeyMultiAutoSubKey(@key id: string, @key id2: string): number {
         return this._get(id) + this._get(id2) +
             this._subscribeWithEnumKeyData[TriggerKeys.First] + this._subscribeWithEnumKeyData[TriggerKeys.Second];
     }


### PR DESCRIPTION
Any @autosubscribe with key params are taken as last in the list, and 0 or more @key'd function parameters come first, in left to right argument order.  This lets you have more hierarchical stores with natural function parameters.  From inside the store, you use the new formCompoundKey utility function to trigger compound-key-based triggers.  See the new SimpleStore functions for examples of how to use it.