### PR TITLE
1.2.2: Discovered that the performance marking code was taking up a b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,10 @@ Whether using ReSub or not, your app will likely scale best if it follows these 
 1. Components should remain pure, and as such, should only get data from props and stores.
 2. Store data should never be modified on the same cycle as component data fetching and rendering. Race conditions and update cycles can form when a component modifies store data while building its state.
 
+## Performance Analysis
+
+To assist with performance analysis of your store and component state-building/-triggering, there is a performance module built into ReSub that marks durations for buildState functions and store trigger callbacks.  If you want to enable it, call the `setPerformanceMarkingEnabled(true)` function available on the root ReSub module export.
+
 ## Using ReSub Without TypeScript
 
 It is fine to use ReSub without TypeScript, but without access to TypeScript’s method decorators, stores and components cannot leverage autosubscriptions, and as such, lose a lot of their value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -10,7 +10,7 @@ import * as React from 'react';
 
 import * as _ from './lodashMini';
 import Options from './Options';
-import Instrumentation from './Instrumentation';
+import * as Instrumentation from './Instrumentation';
 import { SubscriptionCallbackBuildStateFunction, SubscriptionCallbackFunction, StoreSubscription } from './Types';
 import { forbidAutoSubscribeWrapper, enableAutoSubscribeWrapper, enableAutoSubscribe } from './AutoSubscriptions';
 import { assert, noop, normalizeKey } from './utils';
@@ -426,9 +426,9 @@ export abstract class ComponentBase<P extends {}, S extends _.Dictionary<any>> e
             sub.used = false;
         });
 
-        Instrumentation.beginBuildState();
+        if (Instrumentation.impl) { Instrumentation.impl.beginBuildState(); }
         const state = this._buildState(props, initialBuild);
-        Instrumentation.endBuildState(this.constructor);
+        if (Instrumentation.impl) { Instrumentation.impl.endBuildState(this.constructor); }
 
         _.remove(this._handledAutoSubscriptions, subscription => {
             if (this._shouldRemoveAndCleanupAutoSubscription(subscription)) {

--- a/src/ReSub.ts
+++ b/src/ReSub.ts
@@ -18,6 +18,7 @@ export {
 export { ComponentBase } from './ComponentBase';
 export { CustomEqualityShouldComponentUpdate, DeepEqualityShouldComponentUpdate } from './ComponentDecorators';
 export { default as Options } from './Options';
+export { setPerformanceMarkingEnabled } from './Instrumentation';
 export { StoreBase } from './StoreBase';
 export { Types };
 export { formCompoundKey } from './utils';

--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -13,7 +13,7 @@
 
 import * as _ from './lodashMini';
 import Options from './Options';
-import Instrumentation from './Instrumentation';
+import * as Instrumentation from './Instrumentation';
 import { assert, normalizeKey, normalizeKeys, KeyOrKeys } from './utils';
 import { SubscriptionCallbackFunction } from './Types';
 
@@ -207,7 +207,7 @@ export abstract class StoreBase {
 
         StoreBase._isTriggering = true;
         StoreBase._triggerPending = false;
-        Instrumentation.beginInvokeStoreCallbacks();
+        if (Instrumentation.impl) { Instrumentation.impl.beginInvokeStoreCallbacks(); }
 
         let callbacksCount = 0;
         const currentTime = Date.now();
@@ -236,7 +236,7 @@ export abstract class StoreBase {
             callback(keys);
         });
 
-        Instrumentation.endInvokeStoreCallbacks(this.constructor, callbacksCount);
+        if (Instrumentation.impl) { Instrumentation.impl.endInvokeStoreCallbacks(this.constructor, callbacksCount); }
 
         StoreBase._isTriggering = false;
 


### PR DESCRIPTION
…unch of CPU time in heavy-trigger scenarios.  Made it switchable on the fly and off by default.