### PR TITLE
Use new/temporary react lifecycle methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Subclasses should implement some or all of the following methods:
 This method is called to rebuild the module’s state. All but the simplest of components should implement this method. It is called on three occurrences:
 
 1. During initial component construction, `initialBuild` will be true. This is where you should set all initial state for your component. This case rarely needs special treatment because the component always rebuilds all of its state from its props, whether it's an initial build or a new props received event.
-2. In the React lifecycle, during a `componentWillReceiveProps`, if the props change (determined by a `_.isEqual`), this is called so that the component can rebuild its state from the new props.
+2. In the React lifecycle, during a `UNSAFE_componentWillReceiveProps`, if the props change (determined by a `_.isEqual`), this is called so that the component can rebuild its state from the new props.
 3. When this component subscribes to any stores, this will be called whenever the subscription is triggered. This is the most common usage of subscriptions, and the usage created by autosubscriptions.
 
 Any calls from this method to store methods decorated with `@autoSubscribe` will establish an autosubscription.
@@ -283,12 +283,12 @@ This method is automatically called from `componentDidMount` and  `componentDidU
 
 Methods include:
 - `constructor(props: P)`
-- `componentWillMount()`
+- `UNSAFE_componentWillMount()`
 - `componentDidMount()`
 - `componentWillUnmount()`
-- `componentWillUpdate(nextProps: P, nextState: S)`
+- `UNSAFE_componentWillUpdate(nextProps: P, nextState: S)`
 - `componentDidUpdate(prevProps: P, prevState: S)`
-- `componentWillReceiveProps(nextProps: P)`
+- `UNSAFE_componentWillReceiveProps(nextProps: P)`
 
 Many of these methods are unnecessary in simple components thanks to `_componentDidRender` and `_buildState`, but may be overridden if needed. Implementations in subclasses **must** call super.
 
@@ -407,7 +407,7 @@ We have couple of tslint rules to automate search of common problems in ReSub us
 They are located at the `./dist/tslint` folder of the package.
 add following rules to your tslint.json in order to use them.
 
-incorrect-state-access rule doesn't check abstract methods called from componentWillMount, but you could enforce check of your methods by passing them to the rule as an argument.
+incorrect-state-access rule doesn't check abstract methods called from UNSAFE_componentWillMount, but you could enforce check of your methods by passing them to the rule as an argument.
 
 ```
 "incorrect-state-access": [
@@ -417,10 +417,10 @@ incorrect-state-access rule doesn't check abstract methods called from component
 "override-calls-super": [
     true,
     "_buildInitialState",
-    "componentWillMount",
+    "UNSAFE_componentWillMount",
     "componentDidMount",
-    "componentWillReceiveProps",
-    "componentWillUpdate",
+    "UNSAFE_componentWillReceiveProps",
+    "UNSAFE_componentWillUpdate",
     "componentDidUpdate",
     "componentWillUnmount"
 ],

--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -115,13 +115,13 @@ export abstract class ComponentBase<P extends {}, S extends Dictionary<any>> ext
     }
 
     // Subclasses may override, but _MUST_ call super.
-    componentWillMount(): void {
+    UNSAFE_componentWillMount(): void {
         this.setState(this._buildInitialState());
         this._isMounted = true;
     }
 
     // Subclasses may override, but _MUST_ call super.
-    componentWillReceiveProps(nextProps: Readonly<P>, nextContext: any): void {
+    UNSAFE_componentWillReceiveProps(nextProps: Readonly<P>, nextContext: any): void {
         for (const subscriptionKey in this._handledSubscriptions) {
             if (this._handledSubscriptions.hasOwnProperty(subscriptionKey)) {
                 const subscription = this._handledSubscriptions[subscriptionKey];
@@ -168,7 +168,7 @@ export abstract class ComponentBase<P extends {}, S extends Dictionary<any>> ext
         this._isMounted = false;
     }
 
-    componentWillUpdate(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void {
+    UNSAFE_componentWillUpdate(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void {
         // Do nothing, included so that there is no ambiguity on when a subclass must call super
     }
 
@@ -454,7 +454,7 @@ export abstract class ComponentBase<P extends {}, S extends Dictionary<any>> ext
     // 1. In the component constructor, it's called with the initial props and initialBuild = true.  This is where you should set all
     //    initial state for your component.  In many cases this case needs no special casing whatsoever because the component always
     //    rebuilds all of its state from whatever the props are, whether it's an initial build or a new props received event.
-    // 2. In the React lifecycle, during a componentWillReceiveProps, if the props change (determined by a _.isEqual), this is called
+    // 2. In the React lifecycle, during a UNSAFE_componentWillReceiveProps, if the props change (determined by a _.isEqual), this is called
     //    so that the component can rebuild state from the new props.
     // 3. If the component subscribes to any stores via the ComponentBase subscription system, if a specific callback function is not
     //    specified, then this function is called whenever the subscription is triggered.  Basically, this should be used if there are
@@ -468,7 +468,7 @@ export abstract class ComponentBase<P extends {}, S extends Dictionary<any>> ext
         return undefined;
     }
 
-    // The initial state is unavailable in componentWillMount. Override this method to get access to it.
+    // The initial state is unavailable in UNSAFE_componentWillMount. Override this method to get access to it.
     // Subclasses may override, but _MUST_ call super.
     protected _buildInitialState(): Readonly<S> {
         this._initStoreSubscriptions()

--- a/src/tslint/incorrectStateAccessRule.ts
+++ b/src/tslint/incorrectStateAccessRule.ts
@@ -4,7 +4,7 @@
 * Copyright: Microsoft 2017
 *
 * Custom tslint rule used to find cases where the code references
-* this.state from componentWillMount method.
+* this.state from UNSAFE_componentWillMount method.
 */
 
 import * as Lint from 'tslint';
@@ -13,13 +13,13 @@ import { isMethodDeclaration } from 'typescript';
 import { isCallExpression, isPropertyAccessExpression } from 'tsutils';
 
 const DEBUG = false;
-const ERROR_MESSAGE = 'this.state is undefined in componentWillMount callback.';
+const ERROR_MESSAGE = 'this.state is undefined in UNSAFE_componentWillMount callback.';
 
 export class Rule extends Lint.Rules.AbstractRule {
     static metadata: Lint.IRuleMetadata = {
         ruleName: 'incorrect-state-access',
         description: 'Bans state access for ReSub components',
-        rationale: 'In ReSub Component this.state is undefined during componentWillMount. We need to warn users about it.',
+        rationale: 'In ReSub Component this.state is undefined during UNSAFE_componentWillMount. We need to warn users about it.',
         optionsDescription: '',
         options: {},
         type: 'functionality',
@@ -93,7 +93,7 @@ function walk(ctx: Lint.WalkContext<string[]>): void {
             let visitedMethods: {[key: string]: boolean} = {};
             let queue: MethodInfo[] = [];
 
-            const methodsList = ctx.options.concat(['componentWillMount']);
+            const methodsList = ctx.options.concat(['UNSAFE_componentWillMount']);
 
             methodsList.forEach((methodName: string) => {
                 const method =  methods[methodName];


### PR DESCRIPTION
This is a companion to https://github.com/microsoft/reactxp/issues/1039

This migration was performed using the recommend codemod tool:
`npx react-codemod rename-unsafe-lifecycles`
https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods

The converted code will not work on react versions < v16.3 (react-native v0.55)
The converted code will continue to work on react v17.x

The pro of this PR is that it will stop really ugly warning messages with react >= v16.9 (released yesterday)

The con of this PR is that it just defers the actual cognitive work (and associated breaking change) of the real fix which is migrating to different lifecycle methods, but as discussed in the linked reactxp issue, that is a tradeoff between backwards compatibility earlier than react 16.3 (a bit more than a year old, and first used in react-native v0.55) and using the new APIs.

On balance it seemed this transitional step was worthwhile but that is a matter of taste