### PR TITLE
feat/ EntityStores

### DIFF
--- a/src/Entity/DynamicLoadingStore.ts
+++ b/src/Entity/DynamicLoadingStore.ts
@@ -1,0 +1,70 @@
+import {SelectEntityStore} from './SelectEntityStore';
+import {EntityHandler} from './EntityHandler';
+import {EntityStoreProperties} from './EntityStore';
+
+/**
+ * This is the time in seconds, the cache should be valid for one item.
+ */
+const CACHE_INVALIDATION_TIME = 30;
+
+/**
+ * The DynamicLoadingStore tries to retrieve the object from the Backend, if not available.
+ * This is only possible, if the id contains the link to the entity.
+ */
+export class DynamicLoadingStore<entity, id extends string> extends SelectEntityStore<entity, id> {
+    private loadFunction: (id: id) => Promise<entity>;
+    private currentlyLoading: Set<id> = new Set<id>();
+    private cacheTimer: Map<id, Date> = new Map<id, Date>();
+
+    constructor(throttleMs: number | undefined,
+            bypassTriggerBlocks: boolean,
+            entityHandler: EntityHandler<entity, id>,
+            loadFunction: (id: id) => Promise<entity>) {
+        super(throttleMs, bypassTriggerBlocks, entityHandler);
+        this.loadFunction = loadFunction;
+    }
+
+    getOne(ref: id): Readonly<entity> | undefined {
+        const value = super.getOne(ref);
+        const currentTimestamp = new Date(Date.now());
+        const cachedTimestamp = this.cacheTimer.get(ref);
+        if ((!value || !cachedTimestamp || cachedTimestamp.getSeconds() + CACHE_INVALIDATION_TIME < currentTimestamp.getSeconds())
+            && !this.currentlyLoading.has(ref)) {
+            this.loadOne(ref, currentTimestamp);
+        }
+        return value;
+    }
+
+    /**
+     * Force load a object, useful for reloading.
+     * @param ref
+     * @param _currTimestamp
+     */
+    loadOne(ref: id, _currTimestamp?: Date): Promise<entity> {
+        const currentTimestamp = _currTimestamp || new Date(Date.now());
+        this.currentlyLoading.add(ref);
+        this.cacheTimer.set(ref, currentTimestamp);
+        const result = this.loadFunction(ref);
+        result.then((e: entity) => {
+            this.addOrUpdateOne(e);
+            this.currentlyLoading.delete(ref);
+        }, error => this.currentlyLoading.delete(ref));
+        return result;
+    }
+
+    invalidateCache(ref: id): void {
+        this.cacheTimer.delete(ref);
+    }
+}
+
+export interface DynamicLoadingStoreProperties<entity, id extends string> extends EntityStoreProperties<entity, id> {
+    loadFunction: (id: id) => Promise<entity>;
+}
+
+export function createDynamicLoadingStore<entity, id extends string>(props: DynamicLoadingStoreProperties<entity, id>):
+DynamicLoadingStore<entity, id> {
+    return new DynamicLoadingStore<entity, id>(props.throttleMs || undefined,
+        props.bypassTriggerBlocks || false,
+        new EntityHandler<entity, id>(props.selectId),
+        props.loadFunction);
+}

--- a/src/Entity/EntityHandler.ts
+++ b/src/Entity/EntityHandler.ts
@@ -1,0 +1,110 @@
+export class EntityHandler<entity, id extends number | string = number> {
+    private _ids: Set<id> = new Set<id>();
+    private _entities: Map<id, Readonly<entity>> = new Map();
+
+    private readonly _selectId: (entity: Readonly<entity>) => id;
+
+    constructor(selectId: (entity: Readonly<entity>) => id) {
+        this._selectId = selectId;
+    }
+
+    /**
+     * This is only for performance optimization. AddOrUpdate should be the one, you're normally using.
+     * @param entity
+     */
+    addOne(entity: Readonly<entity>): void {
+        const id = this._selectId(entity);
+        this._ids.add(id);
+        this._entities.set(id, entity);
+    }
+
+    addOrUpdateOne(entity: Readonly<entity>): Readonly<entity> | undefined {
+        let result: Readonly<entity> | undefined = undefined;
+        const id = this._selectId(entity);
+        if (this._ids.has(id)) {
+            // id is already there, so we update the old one
+            result = this._entities.get(id);
+        } else {
+            this._ids.add(id);
+        }
+        this._entities.set(id, entity);
+        return result;
+    }
+
+    removeOne(entity: Readonly<entity>): id | undefined {
+        const id = this._selectId(entity);
+        const result = this._entities.delete(id);
+        if (result) {
+            return id;
+        } else {
+            return undefined;
+        }
+    }
+
+    get(ids: Set<id>): Set<entity> {
+        const result: Set<entity> = new Set<entity>();
+        ids.forEach(value => {
+            let e = this._entities.get(value);
+            if (e) {
+                result.add(e);
+            }
+        });
+        return result;
+    }
+
+    addAll(entities: readonly entity[]): void {
+        for (let i = 0; i < entities.length; i++) {
+            this.addOne(entities[i]);
+        }
+    }
+
+    /**
+     * @param entities the new entities
+     * @return the id's of the removed ones
+     */
+    setEntities(entities: readonly entity[]): readonly id[] {
+        if (entities.length === 0) {
+            // shortcut for clearing the entities
+            const result = Array.from(this._ids);
+            this._ids.clear();
+            this._entities.clear();
+            return result;
+        }
+        // create id-set of new entities
+        const newIds = entities.map<id>((value, index, array) => this._selectId(value));
+        // the ids, that are removed are needed in order to trigger the updates correctly
+        const idsToRemove = Array.from(this._ids).filter(value => !newIds.includes(value));
+
+        this._ids.clear();
+        this._entities.clear();
+
+        this.addAll(entities);
+
+        return idsToRemove;
+    }
+
+    getOne(id: id): Readonly<entity> | undefined {
+        return this._entities.get(id);
+    }
+
+    getAll(): readonly entity[] {
+        return Array.from(this._entities, ([id, entity]) => entity).sort(this._sortFn);
+    }
+
+    getId(entity: Readonly<entity>): id {
+        return this._selectId(entity);
+    }
+
+    private _sortFn = (entity1: entity, entity2: entity): number => {
+        let id1 = this._selectId(entity1);
+        let id2 = this._selectId(entity2);
+        if (typeof id1 === 'string' && typeof id2 === 'string') {
+            return id1.localeCompare(id2);
+        } else if (typeof id1 === 'number' && typeof id2 === 'number') {
+            return id1 - id2;
+        } else {
+            // TODO: sort function
+            return 0;
+        }
+    };
+}

--- a/src/Entity/EntityStore.ts
+++ b/src/Entity/EntityStore.ts
@@ -1,0 +1,111 @@
+import {autoSubscribe, AutoSubscribeStore, autoSubscribeWithKey, formCompoundKey, key, StoreBase} from '../ReSub';
+import {EntityHandler} from './EntityHandler';
+
+const triggerEntityKey = '!@ENTITY_TRIGGER@!';
+
+@AutoSubscribeStore
+export class EntityStore<entity, id extends number | string = number> extends StoreBase {
+    protected entityHandler: EntityHandler<entity, id>;
+
+    constructor(throttleMs: number | undefined, bypassTriggerBlocks: boolean, entityHandler: EntityHandler<entity, id>) {
+        super(throttleMs, bypassTriggerBlocks);
+
+        // reset map and ids
+        this.entityHandler = entityHandler;
+    }
+
+    @autoSubscribeWithKey(triggerEntityKey)
+    getAll(): readonly entity[] {
+        return this.entityHandler.getAll();
+    }
+
+    @autoSubscribeWithKey(triggerEntityKey)
+    getOne(id: id): Readonly<entity> | undefined {
+        return this.entityHandler.getOne(id);
+    }
+
+    // TODO: subscribe with corresponding keys...
+    @autoSubscribe
+    getMultiple(ids: Set<id>): Readonly<Set<entity>> {
+        return this.entityHandler.get(ids);
+    }
+
+    /**
+     * @deprecated This is only for performance optimization. AddOrUpdate should be the one, you're normally using.
+     * @param entity
+     */
+    addOne(entity: Readonly<entity>): Readonly<entity> | undefined {
+        return this.addOrUpdateOne(entity);
+    }
+
+    addOrUpdateOne(entity: Readonly<entity>): Readonly<entity> | undefined {
+        let result = this.entityHandler.addOrUpdateOne(entity);
+        this.trigger(formCompoundKey(String(this.entityHandler.getId(entity)), triggerEntityKey));
+        if (result) {
+            // trigger for old entity
+            this.trigger(formCompoundKey(String(this.entityHandler.getId(result)), triggerEntityKey));
+        }
+        return result;
+    }
+
+    /**
+     * @param entity
+     * @returns true, if the element was removed, false, if the element was not present before
+     */
+    removeOne(entity: Readonly<entity>): id | undefined {
+        let result = this.entityHandler.removeOne(entity);
+        this.trigger(formCompoundKey(String(this.entityHandler.getId(entity)), triggerEntityKey));
+        return result;
+    }
+
+    addOrUpdateAll(entities: Readonly<entity[]>): void {
+        StoreBase.pushTriggerBlock();
+        for (const entity of entities) {
+            this.entityHandler.addOne(entity);
+            this.trigger(formCompoundKey(String(this.entityHandler.getId(entity)), triggerEntityKey));
+        }
+
+        this.trigger(triggerEntityKey);
+        StoreBase.popTriggerBlock();
+    }
+
+    setEntities(entities: Readonly<entity[]>): void {
+        if (!(entities instanceof Array)) {
+            throw new Error('setEntities needs an Array');
+        }
+
+        StoreBase.pushTriggerBlock();
+        const removedEntities = this.entityHandler.setEntities(entities);
+        // at first, trigger the removed ones
+        removedEntities.forEach(id => this.trigger(formCompoundKey(String(id), triggerEntityKey)));
+
+        // now trigger for the newly added ones
+        entities.forEach(entity => this.trigger(formCompoundKey(String(this.entityHandler.getId(entity)), triggerEntityKey)));
+        this.trigger(triggerEntityKey);
+
+        StoreBase.popTriggerBlock();
+    }
+
+    /**
+     * Helper function, that returns the id of an entity
+     * @param entity
+     */
+    getId(entity: entity): id {
+        return this.entityHandler.getId(entity);
+    }
+}
+
+key(EntityStore.prototype, 'getOne', 0);
+
+export interface EntityStoreProperties<entity, id extends number | string = number> {
+    throttleMs?: number | undefined;
+    bypassTriggerBlocks?: boolean;
+    selectId: (entity: entity) => id;
+}
+
+export function createEntityStore<entity, id extends number | string = number>(props: EntityStoreProperties<entity, id>):
+EntityStore<entity, id> {
+    return new EntityStore<entity, id>(props.throttleMs || 0,
+        props.bypassTriggerBlocks || false,
+        new EntityHandler<entity, id>(props.selectId));
+}

--- a/src/Entity/SelectEntityStore.ts
+++ b/src/Entity/SelectEntityStore.ts
@@ -1,0 +1,43 @@
+import {EntityStore, EntityStoreProperties} from './EntityStore';
+import {EntityHandler} from './EntityHandler';
+import {autoSubscribeWithKey} from '../ReSub';
+
+const triggerSelectedKey = '!@ENTITY_SELECT_TRIGGER@!';
+
+export class SelectEntityStore<entity, id extends number | string = number> extends EntityStore<entity, id> {
+    protected entityId?: id;
+
+    @autoSubscribeWithKey(triggerSelectedKey)
+    getSelected(): Readonly<entity> | undefined {
+        if (this.entityId === undefined) {
+            return undefined;
+        }
+        return this.getOne(this.entityId);
+    }
+
+    setSelected(id: id | undefined): void {
+        if (id !== this.entityId) {
+            this.entityId = id;
+            this.trigger(triggerSelectedKey);
+        }
+    }
+
+    addOrUpdateOne(entity: Readonly<entity>): Readonly<entity> | undefined {
+        let updateOne = super.addOrUpdateOne(entity);
+        if (this.entityId === this.entityHandler.getId(entity)) {
+            this.trigger(triggerSelectedKey);
+        }
+        return updateOne;
+    }
+}
+
+export interface SelectEntityStoreProperties<entity, id extends number | string = number> extends EntityStoreProperties<entity, id>{
+
+}
+
+export function createSelectEntityStore<entity, id extends number | string = number>(props: SelectEntityStoreProperties<entity, id>):
+SelectEntityStore<entity, id> {
+    return new SelectEntityStore<entity, id>(props.throttleMs || 0,
+        props.bypassTriggerBlocks || false,
+        new EntityHandler<entity, id>(props.selectId));
+}

--- a/src/ReSub.ts
+++ b/src/ReSub.ts
@@ -22,3 +22,6 @@ export { formCompoundKey } from './utils';
 export { ComponentBase } from './ComponentBase';
 export { StoreBase } from './StoreBase';
 export { Types };
+export { createEntityStore, EntityStoreProperties, EntityStore } from './Entity/EntityStore';
+export { createSelectEntityStore, SelectEntityStoreProperties, SelectEntityStore } from './Entity/SelectEntityStore';
+export { createDynamicLoadingStore, DynamicLoadingStoreProperties, DynamicLoadingStore } from './Entity/DynamicLoadingStore';

--- a/test/DynamicLoadingStore.spec.ts
+++ b/test/DynamicLoadingStore.spec.ts
@@ -1,0 +1,67 @@
+import {EntityHandler} from '../src/Entity/EntityHandler';
+import {createDynamicLoadingStore} from '../src/ReSub';
+
+const testValues = new Map<string, string>([['1', 'eins'], ['2', 'zwei'], ['3', 'drei']]);
+
+describe('DynamicLoadingStore', () => {
+    describe('can return the correct ids', () => {
+        it('while setting new entities', () => {
+            const eh = new EntityHandler<number>((entity: number) => entity);
+
+            eh.addAll([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+            expect(eh.getAll().length).toEqual(10);
+
+            const newEntities = [0, 2, 4, 6, 8, 9];
+            const removedEntities = eh.setEntities(newEntities);
+            expect(removedEntities).toEqual([1, 3, 5, 7]);
+            expect(eh.getAll()).toEqual(newEntities);
+        });
+    });
+
+    it('can handle strings as ids', () => {
+        const eh = new EntityHandler<string, string>((entity: string) => entity);
+
+        eh.addAll(['a', 'b', 'c', 'd', 'e']);
+
+        expect(eh.getAll().length).toEqual(5);
+
+        const newEntities = ['a', 'e'];
+        const removedEntities = eh.setEntities(newEntities);
+        expect(removedEntities).toEqual(['b', 'c', 'd']);
+        expect(eh.getAll()).toEqual(newEntities);
+    });
+
+    it('can load values dynamically', (done: any) => {
+        // create store, that gets its value from our testValues
+        const dynamicLoadingStore =
+            createDynamicLoadingStore<string, string>({
+                selectId: entity => entity,
+                loadFunction: id => Promise.resolve(testValues.get(id) || 'undefined'),
+            });
+        expect(dynamicLoadingStore.getAll().length).toEqual(0);
+
+        // dynamically get one
+        const one = dynamicLoadingStore.loadOne('1');
+        one.then(value => {
+            expect(value).toEqual('eins');
+            expect(dynamicLoadingStore.getAll().length).toEqual(1);
+        }, error => fail(error));
+
+        // dynamically get two
+        const two = dynamicLoadingStore.loadOne('2');
+        two.then(two => {
+            expect(two).toEqual('zwei');
+            expect(dynamicLoadingStore.getAll().length).toEqual(2);
+        }, error => fail(error));
+
+        // dynamically get three
+        const three = dynamicLoadingStore.loadOne('3');
+        three.then(three => {
+            expect(three).toEqual('drei');
+            expect(dynamicLoadingStore.getAll().length).toEqual(3);
+        }, error => fail(error));
+
+        Promise.all([one, two, three]).then(value => done());
+    });
+});

--- a/test/EntityHandler.spec.ts
+++ b/test/EntityHandler.spec.ts
@@ -1,0 +1,34 @@
+import {EntityHandler} from '../src/Entity/EntityHandler';
+
+describe('EntityHandler', () => {
+    describe('can return the correct ids', () => {
+        it('while setting new entities', () => {
+            const eh = new EntityHandler<number>((entity: number) => entity);
+
+            eh.addAll([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+            expect(eh.getAll().length).toEqual(10);
+
+            const newEntities = [0, 2, 4, 6, 8, 9];
+            const removedEntities = eh.setEntities(newEntities);
+            expect(removedEntities).toEqual([1, 3, 5, 7]);
+            expect(eh.getAll()).toEqual(newEntities);
+        });
+    });
+
+    describe('can handle strings as ids', () => {
+        it('while setting new entities', () => {
+            const eh = new EntityHandler<string, string>((entity: string) => entity);
+
+            eh.addAll(['a', 'b', 'c', 'd', 'e']);
+
+            expect(eh.getAll().length).toEqual(5);
+
+            const newEntities = ['a', 'e'];
+            const removedEntities = eh.setEntities(newEntities);
+            expect(removedEntities).toEqual(['b', 'c', 'd']);
+            expect(eh.getAll()).toEqual(newEntities);
+        },
+        );
+    });
+});

--- a/test/EntityStore.spec.tsx
+++ b/test/EntityStore.spec.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {createEntityStore, EntityStore} from '../src/Entity/EntityStore';
+import {ComponentBase} from '../src/ReSub';
+import {mount} from 'enzyme';
+
+interface TestParameters<P> {
+    uniqueId: string;
+    testStore: EntityStore<P>;
+    propertyKey: number;
+}
+
+interface TestState<S> {
+    testObject: S;
+}
+
+interface TestObject {
+    key: number;
+    value: number;
+}
+
+class TestComponent extends ComponentBase<TestParameters<TestObject>, TestState<TestObject>> {
+    render(): React.ReactElement<any, string | React.JSXElementConstructor<any>> |
+    string | number | {} | React.ReactNodeArray | React.ReactPortal | boolean | null | undefined {
+        if (!this.state.testObject) {
+            return null;
+        }
+        return this.state.testObject.value;
+    }
+
+    protected _buildState(props: TestParameters<TestObject>, initialBuild: boolean): Partial<TestState<TestObject>> | undefined {
+        return {
+            testObject: this.props.testStore.getOne(this.props.propertyKey),
+        };
+    }
+}
+
+describe('EntityStore', () => {
+    describe('should trigger with correct keys', () => {
+        it('while setting new Entities', () => {
+            const entityTestStore = createEntityStore<TestObject>({selectId: (entity => entity.key)});
+
+            entityTestStore.addOrUpdateAll([{key: 0, value: 0}, {key: 1, value: 1}, {key: 2, value: 2}, {key: 3, value: 3}]);
+            const testComponent = mount(
+                <TestComponent propertyKey={ 1 } testStore={ entityTestStore } uniqueId={ new Date().getTime() + 'X' }/>,
+            );
+
+            expect(testComponent.contains('1')).toEqual(true);
+
+            entityTestStore.setEntities([{key: 1, value: 2}]);
+            testComponent.update();
+            expect(testComponent.contains('2')).toEqual(true);
+
+            entityTestStore.setEntities([{key: 2, value: 2}]);
+            testComponent.update();
+            expect(testComponent.contains('2')).toEqual(false);
+        });
+    });
+
+    describe('Subscription', () => {
+        it('should hold the correct value', async () => {
+            const entityTestStore = createEntityStore<TestObject>({selectId: (entity => entity.key)});
+
+            entityTestStore.addOrUpdateAll([{key: 0, value: 0}, {key: 1, value: 1}, {key: 2, value: 2}]);
+
+            const testComponent1 = mount(
+                <TestComponent propertyKey={ 1 } testStore={ entityTestStore } uniqueId={ new Date().getTime() + '1' }/>,
+            );
+
+            const testComponent2 = mount(
+                <TestComponent propertyKey={ 2 } testStore={ entityTestStore } uniqueId={ new Date().getTime() + '2' }/>,
+            );
+
+            expect(testComponent1.contains('1')).toEqual(true);
+            expect(testComponent2.contains('2')).toEqual(true);
+
+            entityTestStore.addOrUpdateOne({key: 1, value: 2});
+
+            testComponent1.update();
+            testComponent2.update();
+
+            expect(testComponent1.contains('1')).toEqual(false);
+            expect(testComponent1.contains('2')).toEqual(true);
+            expect(testComponent2.contains('2')).toEqual(true);
+
+            entityTestStore.addOrUpdateOne({key: 2, value: 1});
+
+            testComponent1.update();
+            testComponent2.update();
+            expect(testComponent1.contains('2')).toEqual(true);
+            expect(testComponent2.contains('1')).toEqual(true);
+        });
+    });
+});

--- a/test/SelectEntityStore.spec.tsx
+++ b/test/SelectEntityStore.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {ComponentBase, createSelectEntityStore, SelectEntityStore} from '../src/ReSub';
+import {mount} from 'enzyme';
+
+interface TestParameters<P> {
+    testStore: SelectEntityStore<P>;
+}
+
+interface TestState<S> {
+    testObject: S;
+}
+
+interface TestObject {
+    key: number;
+    value: number;
+}
+
+class TestSelectComponent extends ComponentBase<TestParameters<TestObject>, TestState<TestObject>> {
+    render(): React.ReactElement<any, string | React.JSXElementConstructor<any>> |
+    string | number | {} | React.ReactNodeArray | React.ReactPortal | boolean | null | undefined {
+        if (!this.state.testObject) {
+            return null;
+        }
+        return this.state.testObject.value;
+    }
+
+    protected _buildState(props: TestParameters<TestObject>, initialBuild: boolean): Partial<TestState<TestObject>> | undefined {
+        return {
+            testObject: this.props.testStore.getSelected(),
+        };
+    }
+}
+
+describe('Subscription', () => {
+    it('should hold the correct selected value', () => {
+        let entityTestStore = createSelectEntityStore<TestObject>({selectId: (entity => entity.key)});
+
+        entityTestStore.addOrUpdateAll([{key: 0, value: 0}, {key: 1, value: 1}, {key: 2, value: 2}]);
+
+        const testComponent1 = mount(
+            <TestSelectComponent testStore={ entityTestStore }/>,
+        );
+        expect(testComponent1.contains('1')).toEqual(false);
+
+        entityTestStore.setSelected(1);
+        testComponent1.update();
+        expect(testComponent1.contains('1')).toEqual(true);
+
+        entityTestStore.setSelected(2);
+        testComponent1.update();
+        expect(testComponent1.contains('2')).toEqual(true);
+
+        entityTestStore.addOrUpdateOne({key: 2, value: 1});
+        testComponent1.update();
+        expect(testComponent1.contains('1')).toEqual(true);
+    });
+});


### PR DESCRIPTION
I have created some tools to ease the use of ReSub by reducing the boilerplate code.
This PR basically adds 3 types of convenience stores.

**EntityStore**:
A simple store, that holds one type of objects. 

Creating a store works with the method `createEntityStore<EntityType, idType>`.
Creation looks as follows:
```typescript
class SampleObject {
    id: number;
    value: string;
}

const SampleStore = createEntityStore<SampleObject, number>({selectId: (so: SampleObject) => so.id});
```

You now can add objects via `SampleStore.addOrUpdateOne({id: 1, value: 'Hello World!'})`.
And you can get an Object via `SampleStore.getOne(1)`.

**SelectEntityStore**:
The same as the EntityStore, but you can select one item per ID with `SampleStore.setSelected(ID)`.

**DynamicLoadingStore**:
The DynamicLoadingStore is a SelectEntityStore, but with the option to load an object asynchonously, if it does not exist in the store.
This is usefull for example for loading values from a service.

Creation of the DynamicLoadingStore looks as follows:

```typescript
class SampleObject {
    id: number;
    value: string;
}

const sampleObjects: Map<number, SampleObject> = new Map<string, string>([[1, {id: 1, value: 'Hello'}], [2, {id: 1, value: 'Hello'}]]);

const SampleStore = createEntityStore<SampleObject, number>({
    selectId: (so: SampleObject) => so.id,
    loadFunction: (id: number) => sampleObjects[id] 
});
```

`SampleStore.getOne(1)` now loads the Object `{id: 1, value: 'Hello'}` from the sampleObjects map.

*Carefull*:
As it loads values asynchronously, the returnvalue of the getOne function will be undefined on the first call!


If this will be accepted, then I will follow up with an update of the documentation.