### PR TITLE
Adding _startedTrackingSub/_stoppedTrackingSub callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,18 @@ Lifts the trigger block on all stores and releases any queued triggers. If more 
 
 Subclass constructors should call super. `throttleMs` refers to the throttle time (see “Trigger throttling” section). `bypassTriggerBlocks` refers to the trigger blocking system (see “Trigger blocks” section).
 
+##### `_startedTrackingSub(key?: string)`
+
+`StoreBase` uses reference counting on subscriptions. This method is called whenever a subscription is first created, either as a global subscription (key = undefined in this function) or with a key.
+
+Subclasses do not need to call super.
+
+##### `_stoppedTrackingSub(key?: string)`
+
+`StoreBase` uses reference counting on subscriptions. This method is called whenever a subscription is last removed, either as a global subscription (key = undefined in this function) or with a key.
+
+Subclasses do not need to call super.
+
 ##### `_startedTrackingKey(key: string)`
 
 `StoreBase` uses reference counting on subscription keys. This method is called whenever a subscription is created using a new `key`.

--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -257,8 +257,13 @@ export abstract class StoreBase {
         if (!callbacks) {
             this._subscriptions.set(key, [callback]);
 
-            if (key !== StoreBase.Key_All && !this._autoSubscriptions.has(key)) {
-                this._startedTrackingKey(key);
+            // First manual subscription for this key.  See if we also aren't already tracking an auto subscription for it.
+            if (!this._autoSubscriptions.has(key)) {
+                this._startedTrackingSub(key === StoreBase.Key_All ? undefined : key);
+
+                if (key !== StoreBase.Key_All) {
+                    this._startedTrackingKey(key);
+                }
             }
         } else {
             callbacks.push(callback);
@@ -297,8 +302,13 @@ export abstract class StoreBase {
                 // No more callbacks for key, so clear it out
                 this._subscriptions.delete(key);
 
-                if (key !== StoreBase.Key_All && !this._autoSubscriptions.has(key)) {
-                    this._stoppedTrackingKey(key);
+                // Last manual unsubscription for this key.  See if we also aren't already tracking an auto subscription for it.
+                if (!this._autoSubscriptions.has(key)) {
+                    this._stoppedTrackingSub(key === StoreBase.Key_All ? undefined : key);
+
+                    if (key !== StoreBase.Key_All) {
+                        this._stoppedTrackingKey(key);
+                    }
                 }
             }
         } else {
@@ -312,8 +322,13 @@ export abstract class StoreBase {
         if (!callbacks) {
             this._autoSubscriptions.set(key, [subscription]);
 
-            if (key !== StoreBase.Key_All && !this._subscriptions.has(key)) {
-                this._startedTrackingKey(key);
+            // First autosubscription for this key.  See if we also aren't already tracking a manual subscription for it.
+            if (!this._subscriptions.has(key)) {
+                this._startedTrackingSub(key === StoreBase.Key_All ? undefined : key);
+
+                if (key !== StoreBase.Key_All) {
+                    this._startedTrackingKey(key);
+                }
             }
         } else {
             callbacks.push(subscription);
@@ -340,10 +355,23 @@ export abstract class StoreBase {
             // No more callbacks for key, so clear it out
             this._autoSubscriptions.delete(key);
 
-            if (key !== StoreBase.Key_All && !this._subscriptions.has(key)) {
-                this._stoppedTrackingKey(key);
+            // Last autosubscription for this key.  See if we also aren't already tracking a manual subscription for it.
+            if (!this._subscriptions.has(key)) {
+                this._stoppedTrackingSub(key === StoreBase.Key_All ? undefined : key);
+
+                if (key !== StoreBase.Key_All) {
+                    this._stoppedTrackingKey(key);
+                }
             }
         }
+    }
+
+    protected _startedTrackingSub(key?: string): void {
+        // Virtual function, noop default behavior
+    }
+
+    protected _stoppedTrackingSub(key?: string): void {
+        // Virtual function, noop default behavior
     }
 
     protected _startedTrackingKey(key: string): void {

--- a/test/AutoSubscribe.spec.tsx
+++ b/test/AutoSubscribe.spec.tsx
@@ -138,7 +138,7 @@ class OverriddenComponent extends SimpleComponent {
         return mount(<OverriddenComponent { ...props } />);
     }
 
-    static getDerivedStateFromProps: React.GetDerivedStateFromProps<SimpleProps, SimpleState> = (props, state) =>
+    static getDerivedStateFromProps: React.GetDerivedStateFromProps<unknown, unknown> = (props, state) =>
         ComponentBase.getDerivedStateFromProps(props, state);
 }
 


### PR DESCRIPTION
There's currently no way to track unkeyed-subscriptions (subscribe() or @autoSubscribe without a key passed) starting and stopping in your store.  Adding the ability to do so.  Eventually, we'll stop using _started/stoppedTrackingKey, since the new callbacks are a superset of that functionality.  But adding these separately since it's a breaking change from behavior used in the past.  Also added a unit test for both sets of callbacks since apparently we never did that before.  Woopsie.