### PR TITLE
2.1.0: Updated all package dependencies to latest versions.  Eliminat…

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "karma-webpack": "4.0.2",
     "lodash": "^4.17.15",
     "npm-run-all": "4.1.5",
-    "react": "^16.12.0",
+    "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "rimraf": "3.0.2",
     "ts-loader": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "ReactXP Team <reactxp@microsoft.com>",
   "scripts": {
@@ -18,45 +18,45 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
-    "lodash": "^4.17.15",
-    "tslib": "^1.10.0"
+    "tslib": "^1.11.1"
   },
   "peerDependencies": {
     "react": "^16.11.0"
   },
   "devDependencies": {
-    "@types/enzyme": "3.10.4",
-    "@types/enzyme-adapter-react-16": "1.0.5",
-    "@types/jasmine": "3.5.2",
+    "@types/enzyme": "3.10.5",
+    "@types/enzyme-adapter-react-16": "1.0.6",
+    "@types/jasmine": "3.5.10",
     "@types/lodash": "4.14.149",
-    "@types/react": "16.9.19",
+    "@types/react": "16.9.29",
     "@types/react-dom": "16.9.5",
-    "@typescript-eslint/eslint-plugin": "2.19.0",
-    "@typescript-eslint/parser": "2.19.0",
+    "@typescript-eslint/eslint-plugin": "2.26.0",
+    "@typescript-eslint/parser": "2.26.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "eslint": "6.8.0",
     "eslint-config-skype": "1.6.0",
-    "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-react": "7.18.3",
-    "fork-ts-checker-webpack-plugin": "4.0.3",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-react": "7.19.0",
+    "fork-ts-checker-webpack-plugin": "4.1.2",
     "jasmine": "3.5.0",
     "jasmine-core": "3.5.0",
     "karma": "4.4.1",
     "karma-chrome-launcher": "3.1.0",
-    "karma-jasmine": "3.1.0",
-    "karma-jasmine-html-reporter": "1.5.2",
+    "karma-jasmine": "3.1.1",
+    "karma-jasmine-html-reporter": "1.5.3",
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "4.0.2",
+    "lodash": "^4.17.15",
     "npm-run-all": "4.1.5",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "rimraf": "3.0.1",
-    "ts-loader": "6.2.1",
-    "tslint": "6.0.0",
-    "typescript": "3.8.0-dev.20200201",
-    "webpack": "4.41.5"
+    "react-dom": "^16.13.1",
+    "rimraf": "3.0.2",
+    "ts-loader": "6.2.2",
+    "tslint": "6.1.0",
+    "typescript": "3.8.3",
+    "webpack": "4.42.1"
   },
   "repository": {
     "type": "git",

--- a/src/ComponentBase.ts
+++ b/src/ComponentBase.ts
@@ -206,8 +206,8 @@ export abstract class ComponentBase<P = {}, S = {}> extends React.Component<P, S
     // 1. In the component constructor, it's called with the initial props and initialBuild = true.  This is where you should set all
     //    initial state for your component.  In many cases this case needs no special casing whatsoever because the component always
     //    rebuilds all of its state from whatever the props are, whether it's an initial build or a new props received event.
-    // 2. In the React lifecycle, during a UNSAFE_componentWillReceiveProps, if the props change (determined by a _.isEqual), this is called
-    //    so that the component can rebuild state from the new props.
+    // 2. In the React lifecycle, during a UNSAFE_componentWillReceiveProps, if the props change, this is called so that the component
+    //    can rebuild state from the new props.
     // 3. If the component subscribes to any stores via the ComponentBase subscription system, if a specific callback function is not
     //    specified, then this function is called whenever the subscription is triggered.  Basically, this should be used if there are
     //    no performance considerations with simply rebuilding the whole component whenever a subscription is triggered, which is

--- a/src/ComponentDecorators.ts
+++ b/src/ComponentDecorators.ts
@@ -5,8 +5,6 @@
  * Exposes helper decorator functions for use with ReSub Components
  */
 
-import isEqual from 'lodash/isEqual';
-
 import ComponentBase from './ComponentBase';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -16,13 +14,4 @@ export function CustomEqualityShouldComponentUpdate<P extends React.Props<any>, 
         constructor.prototype.shouldComponentUpdate = comparator;
         return constructor;
     };
-}
-
-export function DeepEqualityShouldComponentUpdate<T extends { new(props: any): ComponentBase<any, any> }>(constructor: T): T {
-    return CustomEqualityShouldComponentUpdate<any, any>(deepEqualityComparator)(constructor);
-}
-
-function deepEqualityComparator<P extends React.Props<any>, S = {}>(
-        this: ComponentBase<P, S>, nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): boolean {
-    return isEqual(this.state, nextState) || isEqual(this.props, nextProps) || isEqual(this.context, nextContext);
 }

--- a/src/ReSub.ts
+++ b/src/ReSub.ts
@@ -15,7 +15,7 @@ export {
     autoSubscribe,
     key,
 } from './AutoSubscriptions';
-export { CustomEqualityShouldComponentUpdate, DeepEqualityShouldComponentUpdate } from './ComponentDecorators';
+export { CustomEqualityShouldComponentUpdate } from './ComponentDecorators';
 export { setPerformanceMarkingEnabled } from './Instrumentation';
 export { default as Options } from './Options';
 export { formCompoundKey } from './utils';

--- a/src/StoreBase.ts
+++ b/src/StoreBase.ts
@@ -260,10 +260,6 @@ export abstract class StoreBase {
             // First manual subscription for this key.  See if we also aren't already tracking an auto subscription for it.
             if (!this._autoSubscriptions.has(key)) {
                 this._startedTrackingSub(key === StoreBase.Key_All ? undefined : key);
-
-                if (key !== StoreBase.Key_All) {
-                    this._startedTrackingKey(key);
-                }
             }
         } else {
             callbacks.push(callback);
@@ -305,10 +301,6 @@ export abstract class StoreBase {
                 // Last manual unsubscription for this key.  See if we also aren't already tracking an auto subscription for it.
                 if (!this._autoSubscriptions.has(key)) {
                     this._stoppedTrackingSub(key === StoreBase.Key_All ? undefined : key);
-
-                    if (key !== StoreBase.Key_All) {
-                        this._stoppedTrackingKey(key);
-                    }
                 }
             }
         } else {
@@ -325,10 +317,6 @@ export abstract class StoreBase {
             // First autosubscription for this key.  See if we also aren't already tracking a manual subscription for it.
             if (!this._subscriptions.has(key)) {
                 this._startedTrackingSub(key === StoreBase.Key_All ? undefined : key);
-
-                if (key !== StoreBase.Key_All) {
-                    this._startedTrackingKey(key);
-                }
             }
         } else {
             callbacks.push(subscription);
@@ -358,10 +346,6 @@ export abstract class StoreBase {
             // Last autosubscription for this key.  See if we also aren't already tracking a manual subscription for it.
             if (!this._subscriptions.has(key)) {
                 this._stoppedTrackingSub(key === StoreBase.Key_All ? undefined : key);
-
-                if (key !== StoreBase.Key_All) {
-                    this._stoppedTrackingKey(key);
-                }
             }
         }
     }
@@ -371,14 +355,6 @@ export abstract class StoreBase {
     }
 
     protected _stoppedTrackingSub(key?: string): void {
-        // Virtual function, noop default behavior
-    }
-
-    protected _startedTrackingKey(key: string): void {
-        // Virtual function, noop default behavior
-    }
-
-    protected _stoppedTrackingKey(key: string): void {
         // Virtual function, noop default behavior
     }
 

--- a/test/AutoSubscribe.spec.tsx
+++ b/test/AutoSubscribe.spec.tsx
@@ -19,7 +19,6 @@ import {
 import { mount, ReactWrapper } from 'enzyme';
 
 import ComponentBase from '../src/ComponentBase';
-import { DeepEqualityShouldComponentUpdate } from '../src/ComponentDecorators';
 
 import { StoreBase } from '../src/StoreBase';
 import { formCompoundKey } from '../src/utils';
@@ -140,23 +139,6 @@ class OverriddenComponent extends SimpleComponent {
 
     static getDerivedStateFromProps: React.GetDerivedStateFromProps<unknown, unknown> = (props, state) =>
         ComponentBase.getDerivedStateFromProps(props, state);
-}
-
-@DeepEqualityShouldComponentUpdate
-class DeepEqualitySimpleComponent extends ComponentBase<SimpleProps, SimpleState> {
-    // Note: _buildState is called from ComponentBase's constructor, when props change, and when a store triggers
-    // for which this component is subscribed (e.g. SimpleStore).
-
-    // Auto-subscriptions are enabled in _buildState due to ComponentBase.
-    protected _buildState(props: SimpleProps, initialBuild: boolean): Partial<SimpleState> | undefined {
-        return undefined;
-    }
-
-    render(): ReactElement<any> {
-        return (
-            <div>Not testing render...</div>
-        );
-    }
 }
 
 /**
@@ -552,16 +534,6 @@ function runTests(makeComponent: (props: SimpleProps) => ReactWrapper<SimpleProp
             SimpleStoreInstance.unsubscribe(subToken3);
         });
         SimpleStoreInstance.triggerArbitraryKey(formCompoundKey('a', 'b'));
-    });
-
-    it('Equality decorator override', () => {
-        const simpleComp1 = new SimpleComponent({ ids: [] });
-        const simpleComp2 = new SimpleComponent({ ids: [] });
-        const deepEqual1 = new DeepEqualitySimpleComponent({ ids: [] });
-        const deepEqual2 = new DeepEqualitySimpleComponent({ ids: [] });
-        expect(simpleComp1.shouldComponentUpdate).toEqual(simpleComp2.shouldComponentUpdate);
-        expect(deepEqual1.shouldComponentUpdate).toEqual(deepEqual2.shouldComponentUpdate);
-        expect(simpleComp1.shouldComponentUpdate).not.toEqual(deepEqual1.shouldComponentUpdate);
     });
 }
 

--- a/test/StoreBase.spec.tsx
+++ b/test/StoreBase.spec.tsx
@@ -276,13 +276,10 @@ describe('StoreBase', function() {
         expect(callbackCalled).toBeTruthy();
     });
 
-    it('Started/StoppedTrackingKey/Sub', () => {
+    it('Started/StoppedTrackingSub', () => {
         @AutoSubscribeStore
         class KeyStore extends StoreBase {
-            trackingKey: string | undefined;
-            keyCount = 0;
             getKeyCalls = 0;
-
             subCount = 0;
             getCalls = 0;
 
@@ -296,18 +293,6 @@ describe('StoreBase', function() {
             getSubTest(): number {
                 this.getCalls++;
                 return 3;
-            }
-
-            protected _startedTrackingKey(key: string): void {
-                this.trackingKey = key;
-                this.keyCount++;
-            }
-
-            protected _stoppedTrackingKey(key: string): void {
-                if (this.trackingKey === key) {
-                    this.trackingKey = undefined;
-                }
-                this.keyCount--;
             }
 
             protected _startedTrackingSub(key?: string): void {
@@ -333,26 +318,18 @@ describe('StoreBase', function() {
 
         const s = new KeyStore();
         expect(s.getKeyCalls).toEqual(0);
-        expect(s.keyCount).toEqual(0);
-        expect(s.trackingKey).toEqual(undefined);
         expect(s.getCalls).toEqual(0);
         expect(s.subCount).toEqual(0);
         const wrapper = mount(<DumbComp s={ s } />);
         expect(s.getKeyCalls).toEqual(1);
-        expect(s.keyCount).toEqual(1);
-        expect(s.trackingKey).toEqual('a');
         expect(s.getCalls).toEqual(1);
         expect(s.subCount).toEqual(2);
         (s as any).trigger();
         expect(s.getKeyCalls).toEqual(2);
-        expect(s.keyCount).toEqual(1);
-        expect(s.trackingKey).toEqual('a');
         expect(s.getCalls).toEqual(2);
         expect(s.subCount).toEqual(2);
         wrapper.unmount();
         expect(s.getKeyCalls).toEqual(2);
-        expect(s.keyCount).toEqual(0);
-        expect(s.trackingKey).toEqual(undefined);
         expect(s.getCalls).toEqual(2);
         expect(s.subCount).toEqual(0);
     });


### PR DESCRIPTION
…ed _started/_stoppedTrackingKey in lieu of the new _started/stoppedTrackingSub callbacks added in 2.0.0 final.  Moved deepEqualityComparator into an example in the docs instead of making all users of ReSub take on a hard lodash dependency.