### PR TITLE
2.3.0: Added an auto-subscribe wrapper for functional components to u…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In React’s early days, Flux gave us guidance on how to manage data flow in our
 
 While Flux works well, it can also be cumbersome and error prone. Separate actions, action creators, and stores can result in a great deal of boilerplate code. Developers can fetch data from a store but fail to subscribe to changes, or components can oversubscribe and cause performance issues. Furthermore, developers are left to implement these patterns from scratch.
 
-ReSub aims to eliminate these limitations (and more) through the use of automatic data binding between stores and components called autosubscriptions. By using TypeScript’s method decorators, ReSub components can subscribe to only the data they need on only the stores that provide it, all without writing any code.
+ReSub aims to eliminate these limitations (and more) through the use of automatic data binding between stores and components called autosubscriptions. By using TypeScript’s method decorators, ReSub components can subscribe to only the data they need on only the stores that provide it, all without writing any code.  ReSub works with both traditional class components as well as function components, which is the direction that React seems to be heading for most usage.
 
 ## Basic Example
 
@@ -194,6 +194,31 @@ class UserBoxADisplay extends ComponentBase<SomeProps, SomeState> {
     }
 }
 ```
+
+### withResubAutoSubscriptions
+
+We've added a new hook-like mechanism to ReSub in 2.3.  It uses hooks under the covers, so treat them like hooks for ordering purposes and not using them inside conditional blocks.  It basically uses the same autosubscribe logic from ComponentBase, but it does so from inside function components that have been wrapped in the `withResubAutoSubscriptions` HOC wrapper function.  Let's just jump straight into an example, it'll be more clear.  Let's adapt the initial example from earlier in the doc to the new format.  The `TodosStore` is the same as above, but we can now make the `TodoList` function much simpler.
+
+```typescript
+import * as React from 'react';
+import { withResubAutoSubscriptions } from 'resub';
+
+import TodosStore = require('./TodosStore');
+
+function TodoList() {
+    const todos = TodosStore.getTodos();
+
+    return (
+        <ul className="todos">
+            { this.state.todos.map(todo => <li>{ todo }</li> ) }
+        </ul>
+    );
+}
+
+export default withResubAutoSubscriptions(TodoList);
+```
+
+Much simpler, right?  The call to `getTodos` is intercepted just like it were being called from a `_buildState` class method, and a subscription is automatically generated back to the `TodosStore`, which causes a useState mutation internally if the subscription gets triggered, which then makes the function component re-render again.  Super easy.  Just remember that these methods need to be treated like hooks for all intents and purposes when used like this, and that you need to wrap your function component in the `withResubAutoSubscriptions` call, or else autosubscriptions won't work and you'll be very confused.  In development mode, there's a check that should warn you if you get this wrong, but in production mode (Options.development === false), the check disappears, so you're on your own!
 
 ### ComponentBase
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resub",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "ReactXP Team <reactxp@microsoft.com>",
   "scripts": {

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -228,6 +228,19 @@ function makeAutoSubscribeDecorator(shallow = false, autoSubscribeKeys?: string[
         descriptor.value = function AutoSubscribe(this: any, ...args: any[]) {
             assert(targetWithMetadata.__resubMetadata.__decorated, `Missing @AutoSubscribeStore class decorator: "${ methodNameString }"`);
 
+            if (Options.development) {
+                let inRender = false;
+                try {
+                    useState();
+                    inRender = true;
+                } catch {
+                    // I guess we weren't in render.
+                }
+
+                assert(!inRender || !!handlerWrapper, 'Autosubscribe method called from inside a render function ' +
+                    'or function component without using withResubAutoSubscriptions');
+            }
+
             // Just call the method if no handler is setup.
             const scopedHandleWrapper = handlerWrapper;
             if (!scopedHandleWrapper || scopedHandleWrapper.useAutoSubscriptions === AutoOptions.None) {

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -434,6 +434,6 @@ const autoSubscribeHookHandler = {
     },
 };
 
-export function withResubAutoSubscriptions(func: Function): Function {
+export function withResubAutoSubscriptions<T extends Function>(func: T): T {
     return createAutoSubscribeWrapper(autoSubscribeHookHandler, 1, func, autoSubscribeHookHandler);
 }

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -229,6 +229,11 @@ function makeAutoSubscribeDecorator(shallow = false, autoSubscribeKeys?: string[
             assert(targetWithMetadata.__resubMetadata.__decorated, `Missing @AutoSubscribeStore class decorator: "${ methodNameString }"`);
 
             if (Options.development) {
+                // This is a check to see if we're in a rendering function component function.  If you are, then calling useState will
+                // noop.  If you aren't, then useState will throw an exception.  So, we want to make sure that either you're inside render
+                // and have the call going through a wrapped component, or that you're not inside render, and hence calling the getter
+                // from a store or service or other random non-lifecycled instance, so it's on you to figure out how to manage
+                // subscriptions in that instance.
                 let inRender = false;
                 try {
                     useState();

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -440,5 +440,5 @@ const autoSubscribeHookHandler = {
 };
 
 export function withResubAutoSubscriptions<T extends Function>(func: T): T {
-    return createAutoSubscribeWrapper(autoSubscribeHookHandler, 1, func, autoSubscribeHookHandler);
+    return createAutoSubscribeWrapper(autoSubscribeHookHandler, AutoOptions.Enabled, func, autoSubscribeHookHandler);
 }

--- a/src/AutoSubscriptions.ts
+++ b/src/AutoSubscriptions.ts
@@ -407,22 +407,17 @@ export function warnIfAutoSubscribeEnabled<T extends Function>(target: InstanceT
 }
 
 const autoSubscribeHookHandler = {
-    masterVal: 0,
     handle(self: any, store: StoreBase, key: string) {
-        const [ _, setter ] = useState(this.masterVal);
+        const [ , setter ] = useState();
         useEffect(() => {
             const token = store.subscribe(() => {
-                const val = ++this.masterVal;
-                if (this.masterVal > 1000000000) {
-                    this.masterVal = 0;
-                }
-                setter(val);
+                // Always trigger a rerender
+                setter({});
             }, key);
             return () => {
                 store.unsubscribe(token);
             };
         }, [store, key]);
-        return _;
     },
 };
 

--- a/src/ReSub.ts
+++ b/src/ReSub.ts
@@ -14,6 +14,7 @@ export {
     disableWarnings,
     autoSubscribe,
     key,
+    withResubAutoSubscriptions,
 } from './AutoSubscriptions';
 export { CustomEqualityShouldComponentUpdate } from './ComponentDecorators';
 export { setPerformanceMarkingEnabled } from './Instrumentation';

--- a/src/ReSub.ts
+++ b/src/ReSub.ts
@@ -15,6 +15,7 @@ export {
     autoSubscribe,
     key,
     withResubAutoSubscriptions,
+    enableAutoSubscribeWrapper,
 } from './AutoSubscriptions';
 export { CustomEqualityShouldComponentUpdate } from './ComponentDecorators';
 export { setPerformanceMarkingEnabled } from './Instrumentation';

--- a/test/AutoSubscribe.spec.tsx
+++ b/test/AutoSubscribe.spec.tsx
@@ -16,10 +16,11 @@ import {
     each,
     uniq,
 } from 'lodash';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { mount, ReactWrapper } from 'enzyme';
 
+import { withResubAutoSubscriptions } from '../src/AutoSubscriptions';
 import ComponentBase from '../src/ComponentBase';
-
 import { StoreBase } from '../src/StoreBase';
 import { formCompoundKey } from '../src/utils';
 
@@ -565,4 +566,25 @@ describe('AutoSubscribe', function() {
     });
 
     runTests(makeComponent);
+});
+
+it('Test hook system', function() {
+    SimpleStoreInstance = new SimpleStore();
+
+    function FuncComp(): JSX.Element {
+        const val = SimpleStoreInstance.getDataSingleKeyed();
+        return <>{ val.toString() }</>;
+    }
+    const WrappedFuncComp = withResubAutoSubscriptions(FuncComp);
+
+    const container = mount(<WrappedFuncComp />);
+    expect(container.text()).toEqual('0');
+    expect(SimpleStoreInstance.test_getSubscriptions().get('A').length).toEqual(1);
+    ReactTestUtils.act(() => {
+        SimpleStoreInstance.setStoreDataForKeyedSubscription('A', 3);
+    });
+    container.update();
+    expect(container.text()).toEqual('3');
+    container.unmount();
+    expect(SimpleStoreInstance.test_getSubscriptions().has('A')).toEqual(false);
 });

--- a/test/AutoSubscribe.spec.tsx
+++ b/test/AutoSubscribe.spec.tsx
@@ -570,19 +570,25 @@ describe('AutoSubscribe', function() {
     it('Test hook system', function() {
         SimpleStoreInstance = new SimpleStore();
 
+        let numCalls = 0;
         function FuncComp(): JSX.Element {
+            numCalls++;
             const val = SimpleStoreInstance.getDataSingleKeyed();
             return <>{ val.toString() }</>;
         }
         const WrappedFuncComp = withResubAutoSubscriptions(FuncComp);
 
+        expect(numCalls).toEqual(0);
         const container = mount(<WrappedFuncComp />);
+        expect(numCalls).toEqual(1);
         expect(container.text()).toEqual('0');
         expect(SimpleStoreInstance.test_getSubscriptions().get('A').length).toEqual(1);
         ReactTestUtils.act(() => {
             SimpleStoreInstance.setStoreDataForKeyedSubscription('A', 3);
         });
+        expect(numCalls).toEqual(2);
         container.update();
+        expect(numCalls).toEqual(2);
         expect(container.text()).toEqual('3');
         container.unmount();
         expect(SimpleStoreInstance.test_getSubscriptions().has('A')).toEqual(false);


### PR DESCRIPTION
…se ReSub store getters as hooks.  Automatically manages and ref-counts subscriptions and updates your component when the updates trigger.