### PR TITLE
Replaced prepare script with prepublishOnly, removed src from the published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A library for writing React components that automatically manage subscriptions to data sources simply by accessing them.",
   "author": "ReactXP Team <reactxp@microsoft.com>",
   "scripts": {
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "clean:dist": "rimraf dist*",
     "build:types": "tsc -p tsconfig/types.json",
     "build:es2015": "tsc -p tsconfig.json",
@@ -68,6 +68,11 @@
   "types": "dist-types/ReSub.d.ts",
   "module": "dist-es2015/ReSub.js",
   "main": "dist/ReSub.js",
+  "files": [
+    "dist",
+    "dist-es2015",
+    "dist-types"
+  ],
   "keywords": [
     "react",
     "flux",


### PR DESCRIPTION
The prepare script is ran when the dependencies are installed with `npm install`. The installation could break if dependencies versions clash (happened to me with incompatible versions of tslib).

Proposed solution:
- replace `prepare` with `prepublishOnly`
- add `files` to `package.json` to only include `dist`, `dist-es2015` and `dist-types`  in the npm package.